### PR TITLE
Raise Intercom::ServiceUnavailableError when endpoint returns 502

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -78,7 +78,7 @@ module Intercom
         raise Intercom::ResourceNotFound
       elsif res.code.to_i.eql?(401)
         raise Intercom::AuthenticationError
-      elsif res.code.to_i.eql?(503)
+      elsif res.code.to_i.eql?(502) || res.code.to_i.eql?(503)
         raise Intercom::ServiceUnavailableError
       elsif res.code.to_i.eql?(500)
         raise Intercom::ServerError

--- a/spec/integration/intercom_api_integration_spec.rb
+++ b/spec/integration/intercom_api_integration_spec.rb
@@ -62,10 +62,15 @@ describe "api.intercom.io dummy data requests" do
   end
 
   it "should raise error when endpoint(s) are un-reachable" do
-    FakeWeb.register_uri(:get, %r|example\.com/|, :status => ["503", "Service Unavailable"])
-    Intercom.endpoints = ["http://example.com"]
-    proc { Intercom::User.find(:email => "somebody@example.com")}.must_raise Intercom::ServiceUnavailableError
-    Intercom.endpoints = ["http://example.com", "http://api.example.com"]
-    proc { Intercom::User.find(:email => "somebody@example.com")}.must_raise Intercom::ServiceUnavailableError
+    [
+      ["502", "Bad Gateway"],
+      ["503", "Service Unavailable"]
+    ].each do |status|
+      FakeWeb.register_uri(:get, %r|example\.com/|, :status => status)
+      Intercom.endpoints = ["http://example.com"]
+      proc { Intercom::User.find(:email => "somebody@example.com")}.must_raise Intercom::ServiceUnavailableError
+      Intercom.endpoints = ["http://example.com", "http://api.example.com"]
+      proc { Intercom::User.find(:email => "somebody@example.com")}.must_raise Intercom::ServiceUnavailableError
+    end
   end
 end


### PR DESCRIPTION
Hi, the Gem used to raise this exception when the endpoint would return _502 Bad Gateway_ (which happens from time to time):

``` html
JSON::ParserError: 757: unexpected token at '<html> <head><title>502 Bad Gateway</title></head> <body bgcolor="white"> <center><h1>502 Bad Gateway</h1></center> <hr><center>nginx/1.4.2</center> </body> </html> '
```

This change makes it raise `Intercom::ServiceUnavailableError` instead so it can be rescued reliably in our apps.
