### PR TITLE
Wrap DELETE parameters in request body as json

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -25,7 +25,7 @@ module Intercom
     end
 
     def self.delete(path, params)
-      new(path, Net::HTTP::Delete.new(append_query_string_to_url(path, params), default_headers))
+      new(path, method_with_body(Net::HTTP::Delete, path, params))
     end
 
     def self.put(path, form_data)


### PR DESCRIPTION
This PR fixes https://github.com/intercom/intercom-ruby/issues/60. It wraps the parameters in request body as json, as suggested in api documentation: https://api.intercom.io/docs#deleting_a_user.
