### PR TITLE
Disable inheritance for constants lookup

### DIFF
--- a/lib/intercom/utils.rb
+++ b/lib/intercom/utils.rb
@@ -20,14 +20,14 @@ module Intercom
 
       def constantize_resource_name(resource_name)
         class_name = Utils.singularize(resource_name.capitalize)
-        define_lightweight_class(class_name) unless Intercom.const_defined?(class_name)
+        define_lightweight_class(class_name) unless Intercom.const_defined?(class_name, false)
         namespaced_class_name = "Intercom::#{class_name}"
         Object.const_get(namespaced_class_name)
       end
 
       def constantize_singular_resource_name(resource_name)
         class_name = resource_name.split('_').map(&:capitalize).join
-        define_lightweight_class(class_name) unless Intercom.const_defined?(class_name)
+        define_lightweight_class(class_name) unless Intercom.const_defined?(class_name, false)
         namespaced_class_name = "Intercom::#{class_name}"
         Object.const_get(namespaced_class_name )
       end


### PR DESCRIPTION
[const_defined?](http://www.ruby-doc.org/core-2.0.0/Module.html#method-i-const_defined-3F) has an `inherit` option to enable/disable looking up for constants in ancestors:

_Checks for a constant with the given name in mod If inherit is set, the lookup will also search the ancestors (and Object if mod is a Module.)_

If we leave that option to true, `Intercom.const_defined?` will return true for constants defined in the global namespace, such as an Admin class created for Single Table Inheritance in a typical Rails app. That will cause problems like #80 (this PR solves that problem)
