### PR TITLE
make user_id optional as it is not a attribute for devise user

### DIFF
--- a/lib/intercom/event.rb
+++ b/lib/intercom/event.rb
@@ -84,7 +84,7 @@ module Intercom
     end
     
     def self.user_hash(user)
-      user.user_id ? { :user_id => user.user_id } : { :email => user.email }
+      ((defined? user.user_id) and user.user_id) ? { :user_id => user.user_id } : { :email => user.email }
     end
 
     def self.post_to_intercom(hash)


### PR DESCRIPTION
devise user has no user_id attribute, so here I just make user_id check optional, if user_id is not defined, use email instead.

This fix is for v1.0.0