### PR TITLE
Allow tags to be specified by Hash

### DIFF
--- a/lib/intercom/generic_handlers/tag.rb
+++ b/lib/intercom/generic_handlers/tag.rb
@@ -41,7 +41,12 @@ module Intercom
             end
             
             def tag_object_list(args)
+              return args[1] if hashy_list(args[1])
               args[1].map { |id| { :id => id } }
+            end
+
+            def hashy_list(list)
+              list.size > 0 && list[0].is_a?(Hash) 
             end
             
             def untag_object_list(args)


### PR DESCRIPTION
For example:

```ruby
Intercom::Tag.tag_users 'test', [{email:'foo@bar.io'}]
```

Potential fix for https://github.com/intercom/intercom-ruby/issues/102