### PR TITLE
dont hoist to objects for to/from message params

### DIFF
--- a/lib/intercom/traits/api_resource.rb
+++ b/lib/intercom/traits/api_resource.rb
@@ -67,7 +67,7 @@ module Intercom
       end
 
       def set_property(attribute, value)
-        if typed_value?(value) && !custom_attribute_field?(attribute)
+        if typed_value?(value) && !custom_attribute_field?(attribute) && !message_from_field?(attribute, value) && !message_to_field?(attribute, value)
           value_to_set = Intercom::Lib::TypedJsonDeserializer.new(value).deserialize
         elsif flat_store_attribute?(attribute)
           value_to_set = Intercom::Lib::FlatStore.new(value)
@@ -79,6 +79,14 @@ module Intercom
 
       def custom_attribute_field?(attribute)
         attribute == 'custom_attributes'
+      end
+      
+      def message_from_field?(attribute, value)
+        attribute.to_s == 'from' && value.is_a?(Hash) && value['type']
+      end
+      
+      def message_to_field?(attribute, value)
+        attribute.to_s == 'to' && value.is_a?(Hash) && value['type']
       end
 
       def typed_value?(value)

--- a/spec/unit/intercom/message_spec.rb
+++ b/spec/unit/intercom/message_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "Intercom::Message" do
+
+  let (:user) {Intercom::User.new("email" => "jim@example.com", :user_id => "12345", :created_at => Time.now, :name => "Jim Bob")}
+
+  it 'creates an user message with symbol keys' do
+    Intercom.expects(:post).with('/messages', {'from' => { :type => 'user', :email => 'jim@example.com'}, 'body' => 'halp'}).returns(:status => 200)
+    Intercom::Message.create(:from => { :type => "user", :email => "jim@example.com" }, :body => "halp")
+  end
+  
+  it "creates an user message with string keys" do
+    Intercom.expects(:post).with('/messages', {'from' => { 'type' => 'user', 'email' => 'jim@example.com'}, 'body' => 'halp'}).returns(:status => 200)
+    Intercom::Message.create('from' => { 'type' => "user", 'email' => "jim@example.com" }, 'body' => "halp")
+  end
+  
+  it "creates a admin message" do
+    Intercom.expects(:post).with('/messages', {'from' => { 'type' => "admin", 'id' => "1234" }, 'to' => { 'type' => 'user', 'id' => '5678' }, 'body' => 'halp', 'message_type' => 'inapp'}).returns(:status => 200)
+    Intercom::Message.create('from' => { 'type' => "admin", 'id' => "1234" }, :to => { 'type' => 'user', 'id' => '5678' }, 'body' => "halp", 'message_type' => 'inapp')
+  end
+end


### PR DESCRIPTION
Fixes #115

Question here on whether we should generally never hoist hash attributes to objects on creation; though sometimes this is useful.
