### PR TITLE
distinguish connect vs read timeouts, tested manually by setting api end...

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -58,17 +58,21 @@ module Intercom
       base_uri = URI.parse(target_base_url)
       set_common_headers(net_http_method, base_uri)
       client(base_uri).start do |http|
-        response = http.request(net_http_method)
-        decoded = decode(response['content-encoding'], response.body)
-        unless decoded.strip.empty?
-          parsed_body = JSON.parse(decoded)
-          raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body['type'] == 'error.list'
+        begin
+          response = http.request(net_http_method)
+          decoded = decode(response['content-encoding'], response.body)
+          unless decoded.strip.empty?
+            parsed_body = JSON.parse(decoded)
+            raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body['type'] == 'error.list'
+          end
+          raise_errors_on_failure(response)
+          parsed_body
+        rescue Timeout::Error
+          raise Intercom::ServiceUnavailableError.new('Service Unavailable - read timeout')
         end
-        raise_errors_on_failure(response)
-        parsed_body
       end
     rescue Timeout::Error
-      raise Intercom::ServiceUnavailableError.new('Service Unavailable')
+      raise Intercom::ServiceUnavailableError.new('Service Unavailable - connect timeout')
     end
 
     def decode(content_encoding, body)


### PR DESCRIPTION
...point first to a non routable ip 10.255.255.1 and then to a local service with a forced sleep/delay longer than read timeout

doh - actually just noticing #112 - gonna close this
