### PR TITLE
add global rate limit tracking

### DIFF
--- a/lib/intercom.rb
+++ b/lib/intercom.rb
@@ -36,6 +36,7 @@ module Intercom
   @current_endpoint = nil
   @app_id = nil
   @app_api_key = nil
+  @rate_limit_details = {}
 
   def self.app_id=(app_id)
     @app_id = app_id
@@ -48,8 +49,17 @@ module Intercom
   def self.app_api_key=(app_api_key)
     @app_api_key = app_api_key
   end
+
   def self.app_api_key
     @app_api_key
+  end
+
+  def self.rate_limit_details=(rate_limit_details)
+    @rate_limit_details = rate_limit_details
+  end
+
+  def self.rate_limit_details
+    @rate_limit_details
   end
 
   # This method is obsolete and used to warn of backwards incompatible changes on upgrading


### PR DESCRIPTION
Saves rate limit details, accessible via Intercom class:

``` ruby
Intercom.rate_limit_details
#=> {:limit=>180, :remaining=>179, :reset_at=>2014-10-07 14:58:00 +0100}
```
