### PR TITLE
Avoid circular reference for Ruby 2.2.0

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -3,9 +3,9 @@ module Intercom
   # Base class exception from which all public Intercom exceptions will be derived
   class IntercomError < StandardError
     attr_reader :http_code, :application_error_code
-    def initialize(message, http_code = nil, application_error_code = application_error_code)
+    def initialize(message, http_code = nil, error_code = application_error_code)
       @http_code = http_code
-      @application_error_code = application_error_code
+      @application_error_code = error_code
       super(message)
     end
   end


### PR DESCRIPTION
Ruby 2.2 now prints a warning when it detects an argument defaulting to a variable/method. Renaming things to avoid this warning.
