### PR TITLE
Fix Ruby 2.2.0 Circular Argument Reference Warning

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -3,9 +3,9 @@ module Intercom
   # Base class exception from which all public Intercom exceptions will be derived
   class IntercomError < StandardError
     attr_reader :http_code, :application_error_code
-    def initialize(message, http_code = nil, application_error_code = application_error_code)
+    def initialize(message, http_code = nil, error_code = application_error_code)
       @http_code = http_code
-      @application_error_code = application_error_code
+      @application_error_code = error_code
       super(message)
     end
   end


### PR DESCRIPTION
This fixes this error in ruby 2.2.0:

```
/Users/jwaldrip/.gem/ruby/2.2.0/gems/intercom-2.4.2/lib/intercom/errors.rb:6: warning: circular argument reference - application_error_code
```
