### PR TITLE
Add extra context to IntercomError

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -2,10 +2,12 @@ module Intercom
 
   # Base class exception from which all public Intercom exceptions will be derived
   class IntercomError < StandardError
-    attr_reader :http_code, :application_error_code
-    def initialize(message, http_code = nil, error_code = application_error_code)
-      @http_code = http_code
-      @application_error_code = error_code
+    attr_reader :http_code, :application_error_code, :field, :request_id
+    def initialize(message, context={})
+      @http_code = context[:http_code]
+      @application_error_code = context[:application_error_code]
+      @field = context[:field]
+      @request_id = context[:request_id]
       super(message)
     end
   end

--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -10,6 +10,17 @@ module Intercom
       @request_id = context[:request_id]
       super(message)
     end
+    def inspect
+      attributes = instance_variables.map do |var|
+        value = instance_variable_get(var).inspect
+        "#{var}=#{value}"
+      end
+      "##{self.class.name}:#{message} #{attributes.join(' ')}"
+    end
+    def to_hash
+      {message: message}
+        .merge(Hash[instance_variables.map{ |var| [var[1..-1], instance_variable_get(var)] }])
+    end
   end
 
   # Raised when the credentials you provide don't match a valid account on Intercom.

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -74,7 +74,7 @@ module Intercom
         raise Intercom::ServiceConnectionError.new('Failed to connect to service [connection attempt timed out]')
       end
     end
-    
+
     def decode_body(response)
       decode(response['content-encoding'], response.body)
     end
@@ -124,10 +124,13 @@ module Intercom
       # Currently, we don't support multiple errors
       error_details = error_list_details['errors'].first
       error_code = error_details['type'] || error_details['code']
+      error_field = error_details['field']
       parsed_http_code = (http_code > 0 ? http_code : nil)
       error_context = {
         :http_code => parsed_http_code,
-        :application_error_code => error_code
+        :application_error_code => error_code,
+        :field => error_field,
+        :request_id => error_list_details['request_id']
       }
       case error_code
       when 'unauthorized', 'forbidden'


### PR DESCRIPTION
Add a couple fields that come in handy when things go wrong.
* `request_id` that helps when contacting intercom support
* `field` that denotes the cause of a validation error

