### PR TITLE
Adding support for parameter_not_found and unique_user_constraint error codes.

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -136,7 +136,7 @@ module Intercom
       case error_code
       when 'unauthorized', 'forbidden'
         raise Intercom::AuthenticationError.new(error_details['message'], error_context)
-      when "bad_request", "missing_parameter", 'parameter_invalid'
+      when "bad_request", "missing_parameter", 'parameter_invalid', 'parameter_not_found'
         raise Intercom::BadRequestError.new(error_details['message'], error_context)
       when "not_found"
         raise Intercom::ResourceNotFound.new(error_details['message'], error_context)
@@ -144,7 +144,7 @@ module Intercom
         raise Intercom::RateLimitExceeded.new(error_details['message'], error_context)
       when 'service_unavailable'
         raise Intercom::ServiceUnavailableError.new(error_details['message'], error_context)
-      when 'conflict'
+      when 'conflict', 'unique_user_constraint'
         raise Intercom::MultipleMatchingUsersError.new(error_details['message'], error_context)
       when nil, ''
         raise Intercom::UnexpectedError.new(message_for_unexpected_error_without_type(error_details, parsed_http_code), error_context)


### PR DESCRIPTION
This [python-intercom issue](https://github.com/jkeyes/python-intercom/issues/97) identifies two error codes that were not handled directly in python-intercom or intercom-ruby.

I didn't see any tests for the error codes, that's why there are none added to this PR. Hope this helps.