### PR TITLE
Support token keyword for oauth clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Using bundler:
 
 ```ruby
 intercom = Intercom::Client.new(app_id: 'my_app_id', api_key: 'my_api_key')
+
+# With an OAuth token:
+intercom = Intercom::Client.new(token: 'my_token')
 ```
 
 You can get your `app_id` from the URL when you're logged into Intercom (it's the alphanumeric just after `/apps/`) and your API key from the API keys integration settings page (under your app settings - integrations in Intercom).

--- a/spec/unit/intercom/client_spec.rb
+++ b/spec/unit/intercom/client_spec.rb
@@ -20,5 +20,13 @@ module Intercom
     it 'should raise on nil credentials' do
       proc { Client.new(app_id: nil, api_key: nil) }.must_raise MisconfiguredClientError
     end
+
+    describe 'OAuth clients' do
+      it 'supports "token"' do
+        client = Client.new(token: 'foo')
+        client.username_part.must_equal('foo')
+        client.password_part.must_equal('')
+      end
+    end
   end
 end


### PR DESCRIPTION
With some internal refactoring to use the Basic auth lingo instead of `app_id` and `api_key`