### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ intercom.conversations.reply(:id => conversation.id, :type => 'user', :email => 
 # Admin (identified by id) replies with a comment
 intercom.conversations.reply(:id => conversation.id, :type => 'admin', :admin_id => '123', :message_type => 'comment', :body => 'bar')
 # User (identified by email) replies with a comment and attachment
-intercom.conversations.reply(:id => conversation.id, :type => 'user', :email => 'joe@example.com', :message_type => 'comment', :body => 'foo', :attachment => ['http://www.example.com/attachment.jpg'])
+intercom.conversations.reply(:id => conversation.id, :type => 'user', :email => 'joe@example.com', :message_type => 'comment', :body => 'foo', :attachment_urls => ['http://www.example.com/attachment.jpg'])
 
 # Open
 intercom.conversations.open(id: conversation.id, admin_id: '123')


### PR DESCRIPTION
#194 typo-ed the argument name for attachment uploads