### PR TITLE
Force unzipped body to UTF-8 encoding

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -105,7 +105,7 @@ module Intercom
 
     def decode(content_encoding, body)
       return body if (!body) || body.empty? || content_encoding != 'gzip'
-      Zlib::GzipReader.new(StringIO.new(body)).read
+      Zlib::GzipReader.new(StringIO.new(body)).read.force_encoding("utf-8")
     end
 
     def raise_errors_on_failure(res)


### PR DESCRIPTION
Seems the Ruby JSON parser does not like the default encoding from GzipReader - it returns "Encoding::InvalidByteSequenceError: "\xC3" on US-ASCII".