### PR TITLE
Get global conversation count

### DIFF
--- a/lib/intercom/service/count.rb
+++ b/lib/intercom/service/count.rb
@@ -15,7 +15,9 @@ module Intercom
       end
 
       def for_type(type:, count: nil)
-        find(type: type, count: count)
+        params = {type: type}
+        params[:count] = count if count
+        find(params)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -448,6 +448,18 @@ def test_segment_count
   }
 end
 
+def test_conversation_count
+  {
+    "type" => "count",
+    "conversation" => {
+      "assigned" => 1,
+      "closed" => 15,
+      "open" => 1,
+      "unassigned" => 0
+    }
+  }
+end
+
 def error_on_modify_frozen
   RUBY_VERSION =~ /1.8/ ? TypeError : RuntimeError
 end

--- a/spec/unit/intercom/count_spec.rb
+++ b/spec/unit/intercom/count_spec.rb
@@ -14,4 +14,10 @@ describe "Intercom::Count" do
     counts = client.counts.for_type(type: 'user', count: 'segment')
     counts.user['segment'][4]["segment 1"].must_equal(1)
   end
+
+  it 'should not include count param when nil' do
+    client.expects(:get).with("/counts", {type: 'conversation'}).returns(test_segment_count)
+    counts = client.counts.for_type(type: 'conversation')
+    counts.user['segment'][4]["segment 1"].must_equal(1)
+  end
 end

--- a/spec/unit/intercom/count_spec.rb
+++ b/spec/unit/intercom/count_spec.rb
@@ -16,8 +16,13 @@ describe "Intercom::Count" do
   end
 
   it 'should not include count param when nil' do
-    client.expects(:get).with("/counts", {type: 'conversation'}).returns(test_segment_count)
+    client.expects(:get).with("/counts", {type: 'conversation'}).returns(test_conversation_count)
     counts = client.counts.for_type(type: 'conversation')
-    counts.user['segment'][4]["segment 1"].must_equal(1)
+    counts.conversation.must_equal({
+      "assigned" => 1,
+      "closed" => 15,
+      "open" => 1,
+      "unassigned" => 0
+    })
   end
 end


### PR DESCRIPTION
When trying to get the global conversation count `https://api.intercom.io/counts?type=conversation` you want to use the interface `intercom.counts.for_type(type: 'conversation')`

However, this currently doesn't work because the gem passes the empty `count=` param to the API which results in a server error: `Intercom::BadRequestError: for a conversation type, the count parameter must be admin`.

I changed the code so it won't send the count param to the server when it's nil.