### PR TITLE
Fix name of base Intercom error class in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ intercom = Intercom::Client.new(app_id: 'my_app_id', api_key: 'my_api_key')
 
 You can get your `app_id` from the URL when you're logged into Intercom (it's the alphanumeric just after `/apps/`) and your API key from the API keys integration settings page (under your app settings - integrations in Intercom).
 
-```ruby 
+```ruby
 # With an OAuth token:
 intercom = Intercom::Client.new(token: 'my_token')
 ```
@@ -444,10 +444,9 @@ intercom.jobs.errors(id: 'job_abcd1234')
 
 There are different styles for error handling - some people prefer exceptions; some prefer nil and check; some prefer error objects/codes. Balancing these preferences alongside our wish to provide an idiomatic gem has brought us to use the current mechanism of throwing specific exceptions. Our approach in the client is to propagate errors and signal our failure loudly so that erroneous data does not get propagated through our customers' systems - in other words, if you see a `Intercom::ServiceUnavailableError` you know where the problem is.
 
-You do not need to deal with the HTTP response from an API call directly. If there is an unsuccessful response then an error that is a subclass of `Intercom::Error` will be raised. If desired, you can get at the http_code of an `Intercom::Error` via its `http_code` method.
+You do not need to deal with the HTTP response from an API call directly. If there is an unsuccessful response then an error that is a subclass of `Intercom::IntercomError` will be raised. If desired, you can get at the http_code of an `Intercom::IntercomError` via its `http_code` method.
 
-The list of different error subclasses are listed below. As they all inherit off Intercom::IntercomError you can choose to rescue Intercom::IntercomError or
-else rescue the more specific error subclass.
+The list of different error subclasses are listed below. As they all inherit off Intercom::IntercomError you can choose to rescue Intercom::IntercomError or else rescue the more specific error subclass.
 
 ```ruby
 Intercom::AuthenticationError


### PR DESCRIPTION
The base class for all intercom errors is `Intercom::IntercomError`, not
`Intercom::Error`, as the README previously stated.