### PR TITLE
Allow pagination for Ruby SDK

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,61 @@ def test_user(email="bob@example.com")
   }
 end
 
+def test_user_dates(email="bob@example.com", created_at=1401970114, last_request_at=1401970113)
+  {
+      "type" =>"user",
+      "id" =>"aaaaaaaaaaaaaaaaaaaaaaaa",
+      "user_id" => 'id-from-customers-app',
+      "email" => email,
+      "name" => "Joe Schmoe",
+      "avatar" => {"type"=>"avatar", "image_url"=>"https://graph.facebook.com/1/picture?width=24&height=24"},
+      "app_id" => "the-app-id",
+      "custom_attributes" => {"a" => "b", "b" => 2},
+      "companies" =>
+          {"type"=>"company.list",
+           "companies"=>
+               [{"type"=>"company",
+                 "company_id"=>"123",
+                 "id"=>"bbbbbbbbbbbbbbbbbbbbbbbb",
+                 "app_id"=>"the-app-id",
+                 "name"=>"Company 1",
+                 "remote_created_at"=>1390936440,
+                 "created_at"=>1401970114,
+                 "updated_at"=>1401970114,
+                 "last_request_at"=>1401970113,
+                 "monthly_spend"=>0,
+                 "session_count"=>0,
+                 "user_count"=>1,
+                 "tag_ids"=>[],
+                 "custom_attributes"=>{"category"=>"Tech"}}]},
+      "session_count" => 123,
+      "unsubscribed_from_emails" => true,
+      "last_request_at" =>last_request_at,
+      "created_at" =>created_at,
+      "remote_created_at" =>1393613864,
+      "updated_at" =>1401970114,
+      "user_agent_data" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.56 Safari/535.11",
+      "social_profiles" =>{"type"=>"social_profile.list",
+                           "social_profiles" => [
+                               {"type" => "social_profile", "name" => "twitter", "url" => "http://twitter.com/abc", "username" => "abc", "id" => nil},
+                               {"type" => "social_profile", "name" => "twitter", "username" => "abc2", "url" => "http://twitter.com/abc2", "id" => nil},
+                               {"type" => "social_profile", "name" => "facebook", "url" => "http://facebook.com/abc", "username" => "abc", "id" => "1234242"},
+                               {"type" => "social_profile", "name" => "quora", "url" => "http://facebook.com/abc", "username" => "abc", "id" => "1234242"}
+                           ]},
+      "location_data"=>
+          {"type"=>"location_data",
+           "city_name"=> 'Dublin',
+           "continent_code"=> 'EU',
+           "country_name"=> 'Ireland',
+           "latitude"=> '90',
+           "longitude"=> '10',
+           "postal_code"=> 'IE',
+           "region_name"=> 'Europe',
+           "timezone"=> '+1000',
+           "country_code" => "IRL"}
+  }
+end
+
 def test_admin_list
   {
     "type" => "admin.list",
@@ -158,6 +213,23 @@ def page_of_users(include_next_link= false)
       },
       "users"=> [test_user("user1@example.com"), test_user("user2@example.com"), test_user("user3@example.com")],
       "total_count"=>314
+  }
+end
+
+def users_pagination(include_next_link=false, per_page=0, page=0, total_pages=0, total_count=0, user_list=[])
+  {
+      "type"=>"user.list",
+      "pages"=>
+          {
+              "type"=>"pages",
+              "next"=> (include_next_link ? "https://api.intercom.io/users?per_page=" \
+                                            + per_page.to_s + "&page=" +  (page+1).to_s : nil),
+              "page"=>page,
+              "per_page"=>per_page,
+              "total_pages"=>total_pages
+          },
+      "users"=> user_list,
+      "total_count"=>total_count
   }
 end
 

--- a/spec/unit/intercom/client_collection_proxy_spec.rb
+++ b/spec/unit/intercom/client_collection_proxy_spec.rb
@@ -32,4 +32,49 @@ describe Intercom::ClientCollectionProxy do
     client.expects(:get).with("/users", {:tag_name => 'Taggart J'}).returns(page_of_users(false))
     client.users.find_all(:tag_name => 'Taggart J').map(&:email).must_equal %W(user1@example.com user2@example.com user3@example.com)
   end
+
+  it "supports single page pagination" do
+    users = [test_user("user1@example.com"), test_user("user2@example.com"), test_user("user3@example.com"),
+     test_user("user4@example.com"), test_user("user5@example.com"), test_user("user6@example.com"),
+     test_user("user7@example.com"), test_user("user8@example.com"), test_user("user9@example.com"),
+     test_user("user10@example.com")]
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 10, :page => 1}).returns(users_pagination(false, per_page=10, page=1, total_pages=1, total_count=10, user_list=users))
+    result = client.users.find_all(:type=>'users', :per_page => 10, :page => 1).map {|user| user.email }
+    result.must_equal %W(user1@example.com user2@example.com user3@example.com user4@example.com user5@example.com user6@example.com user7@example.com user8@example.com user9@example.com user10@example.com)
+  end
+
+  it "supports multi page pagination" do
+    users = [test_user("user3@example.com"), test_user("user4@example.com")]
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 2, :page => 3}).returns(users_pagination(true, per_page=2, page=3, total_pages=5, total_count=10, user_list=users))
+    result = client.users.find_all(:type=>'users', :per_page => 2, :page => 3).map {|user| user.email }
+    result.must_equal %W(user3@example.com user4@example.com)
+  end
+
+  it "works with page out of range request" do
+    users = []
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 2, :page => 30}).returns(users_pagination(true, per_page=2, page=30, total_pages=2, total_count=3, user_list=users))
+    result = client.users.find_all(:type=>'users', :per_page => 2, :page => 30).map {|user| user.email }
+    result.must_equal %W()
+  end
+
+  it "works with asc order" do
+    test_date=1457337600
+    time_increment=1000
+    users = [test_user_dates(email="user1@example.com", created_at=test_date), test_user_dates(email="user2@example.com", created_at=test_date-time_increment),
+             test_user_dates(email="user3@example.com", created_at=test_date-2*time_increment), test_user_dates(email="user4@example.com", created_at=test_date-3*time_increment)]
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 4, :page => 5, :order => "asc", :sort => "created_at"}).returns(users_pagination(true, per_page=4, page=5, total_pages=6, total_count=30, user_list=users))
+    result = client.users.find_all(:type=>'users', :per_page => 4, :page => 5, :order => "asc", :sort => "created_at").map(&:email)
+    result.must_equal %W(user1@example.com user2@example.com user3@example.com user4@example.com)
+  end
+
+  it "works with desc order" do
+    test_date=1457337600
+    time_increment=1000
+    users = [test_user_dates(email="user4@example.com", created_at=3*test_date), test_user_dates(email="user3@example.com", created_at=test_date-2*time_increment),
+             test_user_dates(email="user2@example.com", created_at=test_date-time_increment), test_user_dates(email="user1@example.com", created_at=test_date)]
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 4, :page => 5, :order => "desc", :sort => "created_at"}).returns(users_pagination(true, per_page=4, page=5, total_pages=6, total_count=30, user_list=users))
+    result = client.users.find_all(:type=>'users', :per_page => 4, :page => 5, :order => "desc", :sort => "created_at").map {|user| user.email }
+    result.must_equal %W(user4@example.com user3@example.com user2@example.com user1@example.com)
+  end
+
 end


### PR DESCRIPTION
This is related to https://github.com/intercom/intercom-ruby/issues/215
Previously we were returning all of the elements in a request even if the user specified a single page of results. Just adding in a check here to monitor the current page and return that page if that is what the user specified. This will allow users to specific the per page request number and the specific page they want returned.