### PR TITLE
Feature: Rate Limit Error Handling

### DIFF
--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -2,7 +2,7 @@ module Intercom
   class MisconfiguredClientError < StandardError; end
   class Client
     include Options
-    attr_reader :base_url, :rate_limit_details, :username_part, :password_part
+    attr_reader :base_url, :rate_limit_details, :username_part, :password_part, :handle_rate_limit
 
     class << self
       def set_base_url(base_url)
@@ -14,7 +14,7 @@ module Intercom
       end
     end
 
-    def initialize(app_id: 'my_app_id', api_key: 'my_api_key', token: nil)
+    def initialize(app_id: 'my_app_id', api_key: 'my_api_key', token: nil, handle_rate_limit: false)
       if token
         @username_part = token
         @password_part = ""
@@ -26,6 +26,7 @@ module Intercom
 
       @base_url = 'https://api.intercom.io'
       @rate_limit_details = {}
+      @handle_rate_limit = handle_rate_limit
     end
 
     def admins
@@ -108,6 +109,7 @@ module Intercom
     end
 
     def execute_request(request)
+      request.handle_rate_limit = handle_rate_limit
       result = request.execute(@base_url, username: @username_part, secret: @password_part)
       @rate_limit_details = request.rate_limit_details
       result

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -3,7 +3,7 @@ require 'net/https'
 
 module Intercom
   class Request
-    attr_accessor :path, :net_http_method, :rate_limit_details
+    attr_accessor :path, :net_http_method, :rate_limit_details, :handle_rate_limit
 
     def initialize(path, net_http_method)
       self.path = path
@@ -70,9 +70,13 @@ module Intercom
             parsed_body = parse_body(decoded_body, response)
             raise_errors_on_failure(response)
             parsed_body
-          rescue Intercom::RateLimitExceeded
-            sleep (response.rate_limit_details[:reset_at] - Time.now.utc).ceiling
-            retry
+          rescue Intercom::RateLimitExceeded => e
+            if @handle_rate_limit
+              sleep (response.rate_limit_details[:reset_at] - Time.now.utc).ceiling
+              retry
+            else
+              raise e
+            end
           rescue Timeout::Error
             raise Intercom::ServiceUnavailableError.new('Service Unavailable [request timed out]')
           end

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -70,6 +70,9 @@ module Intercom
             parsed_body = parse_body(decoded_body, response)
             raise_errors_on_failure(response)
             parsed_body
+          rescue Intercom::RateLimitExceeded
+            sleep (response.rate_limit_details[:reset_at] - Time.now.utc).ceiling
+            retry
           rescue Timeout::Error
             raise Intercom::ServiceUnavailableError.new('Service Unavailable [request timed out]')
           end


### PR DESCRIPTION
## Hey Rate Limit don't bring me problems, bring me solutions!

A patch to give users an option to automatically handle rate limit errors with `sleep` till rate limit reset then retry. Default behaviour is unchanged.

The option can be set on initialization of the `Client` or set on individual `Request`s before execution.

It needs a unit test really but first let's just see if you like the idea.

🐧 User's system clock needs to be quite well synced to intercom's for the feature to be effective. Would be good if one of the api endpoints exposed the intercom system time.
