### PR TITLE
Issue 274 - Add Scroll Functionality 

### DIFF
--- a/lib/intercom/api_operations/scroll.rb
+++ b/lib/intercom/api_operations/scroll.rb
@@ -1,0 +1,16 @@
+require 'intercom/scroll_collection_proxy'
+
+module Intercom
+  module ApiOperations
+    module Scroll
+
+      def scroll()
+        collection_name = Utils.resource_class_to_collection_name(collection_class)
+        finder_details = {}
+        finder_details[:url] = "/#{collection_name}"
+        ScrollCollectionProxy.new(collection_name, finder_details: finder_details,  client: @client)
+      end
+
+    end
+  end
+end

--- a/lib/intercom/scroll_collection_proxy.rb
+++ b/lib/intercom/scroll_collection_proxy.rb
@@ -1,0 +1,83 @@
+require "intercom/utils"
+require "ext/sliceable_hash"
+
+module Intercom
+  class ScrollCollectionProxy
+
+    attr_reader :resource_name, :scroll_url, :resource_class, :scroll_param, :users
+
+    def initialize(resource_name, finder_details: {}, client:)
+      @resource_name = resource_name
+      @resource_class = Utils.constantize_resource_name(resource_name)
+      @scroll_url = (finder_details[:url] || "/#{@resource_name}") + '/scroll'
+      @client = client
+
+    end
+
+    def next(scroll_paramater=nil)
+      @users = []
+      if not scroll_paramater
+        #First time so do initial get without scroll_param
+        response_hash = @client.get(@scroll_url, '')
+      else
+        #Not first call so use get next page
+        response_hash = @client.get(@scroll_url, scroll_param: scroll_paramater)
+      end
+      raise Intercom::HttpError.new('Http Error - No response entity returned') unless response_hash
+      @scroll_param = extract_scroll_param(response_hash)
+      top_level_entity_key = deserialize_response_hash(response_hash)
+      response_hash[top_level_entity_key] = response_hash[top_level_entity_key].map do |object_json|
+        Lib::TypedJsonDeserializer.new(object_json).deserialize
+      end
+      @users = response_hash['users']
+      self
+    end
+
+    def each(&block)
+      scroll_param = nil
+      loop do
+        if not scroll_param
+          response_hash = @client.get(@scroll_url, '')
+        else
+          response_hash = @client.get(@scroll_url, scroll_param: scroll_param)
+        end
+        raise Intercom::HttpError.new('Http Error - No response entity returned') unless response_hash
+        response_hash[deserialize_response_hash(response_hash)].each do |object_json|
+          block.call Lib::TypedJsonDeserializer.new(object_json).deserialize
+        end
+        scroll_param = extract_scroll_param(response_hash)
+        break if not users_present?(response_hash)
+      end
+      self
+    end
+
+    def [](target_index)
+      self.each_with_index do |item, index|
+        return item if index == target_index
+      end
+      nil
+    end
+
+    include Enumerable
+
+    private
+
+    def deserialize_response_hash(response_hash)
+      top_level_type = response_hash.delete('type')
+      if resource_name == 'subscriptions'
+        top_level_entity_key = 'items'
+      else
+        top_level_entity_key = Utils.entity_key_from_type(top_level_type)
+      end
+    end
+
+    def users_present?(response_hash)
+      (response_hash['users'].length > 0)
+    end
+
+    def extract_scroll_param(response_hash)
+      return nil unless users_present?(response_hash)
+      response_hash['scroll_param']
+    end
+  end
+end

--- a/lib/intercom/service/user.rb
+++ b/lib/intercom/service/user.rb
@@ -1,6 +1,7 @@
 require 'intercom/service/base_service'
 require 'intercom/api_operations/load'
 require 'intercom/api_operations/list'
+require 'intercom/api_operations/scroll'
 require 'intercom/api_operations/find'
 require 'intercom/api_operations/find_all'
 require 'intercom/api_operations/save'
@@ -14,6 +15,7 @@ module Intercom
     class User < BaseService
       include ApiOperations::Load
       include ApiOperations::List
+      include ApiOperations::Scroll
       include ApiOperations::Find
       include ApiOperations::FindAll
       include ApiOperations::Save

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -216,6 +216,14 @@ def page_of_users(include_next_link= false)
   }
 end
 
+def users_scroll(include_users= false)
+  {
+      "type"=>"user.list",
+      "scroll_param"=> ("da6bbbac-25f6-4f07-866b-b911082d7"),
+      "users"=> (include_users ? [test_user("user1@example.com"), test_user("user2@example.com"), test_user("user3@example.com")] : []),
+  }
+end
+
 def users_pagination(include_next_link=false, per_page=0, page=0, total_pages=0, total_count=0, user_list=[])
   {
       "type"=>"user.list",

--- a/spec/unit/intercom/scroll_collection_proxy_spec.rb
+++ b/spec/unit/intercom/scroll_collection_proxy_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe Intercom::ScrollCollectionProxy do
+  let (:client) { Intercom::Client.new(app_id: 'app_id',  api_key: 'api_key') }
+
+  it "stops iterating if no users returned" do
+    client.expects(:get).with("/users/scroll", '').returns(users_scroll(false))
+    emails = []
+    client.users.scroll.each { |user| emails << user.email }
+    emails.must_equal %W()
+  end
+
+  it "keeps iterating if users returned" do
+    client.expects(:get).with("/users/scroll", '').returns(users_scroll(true))
+    client.expects(:get).with('/users/scroll', {:scroll_param => 'da6bbbac-25f6-4f07-866b-b911082d7'}).returns(users_scroll(false))
+    emails = []
+    client.users.scroll.each { |user| emails << user.email }
+  end
+
+  it "supports indexed array access" do
+    client.expects(:get).with("/users/scroll", '').returns(users_scroll(true))
+    client.users.scroll[0].email.must_equal 'user1@example.com'
+  end
+
+  it "supports map" do
+    client.expects(:get).with("/users/scroll", '').returns(users_scroll(true))
+    client.expects(:get).with('/users/scroll', {:scroll_param => 'da6bbbac-25f6-4f07-866b-b911082d7'}).returns(users_scroll(false))
+    emails = client.users.scroll.map { |user| user.email }
+    emails.must_equal %W(user1@example.com user2@example.com user3@example.com)
+  end
+
+  it "returns one page scroll" do
+    client.expects(:get).with("/users/scroll", '').returns(users_scroll(true))
+    users = client.users.scroll.next
+    emails = []
+    users.users.each {|usr| emails << usr.email}
+    emails.must_equal %W(user1@example.com user2@example.com user3@example.com)
+  end
+
+  it "keeps iterating if called with scroll_param" do
+    client.expects(:get).with("/users/scroll", '').returns(users_scroll(true))
+    client.expects(:get).with('/users/scroll', {:scroll_param => 'da6bbbac-25f6-4f07-866b-b911082d7'}).returns(users_scroll(true))
+    users = client.users.scroll.next
+    users = client.users.scroll.next('da6bbbac-25f6-4f07-866b-b911082d7')
+    emails =[]
+    users.users.each {|usr| puts usr.email}
+  end
+
+  it "works with an empty list" do
+    client.expects(:get).with("/users/scroll", '').returns(users_scroll(false))
+    scroll = client.users.scroll.next
+    emails = []
+    scroll.users.each {|usr| emails << usr.email}
+    emails.must_equal %W()
+  end
+end


### PR DESCRIPTION
The scroll functionality does not allow for pagination or parameters such as order as described [here](https://developers.intercom.io/reference#iterating-over-all-users). As a result you cannot perform pagination via the scroll and would instead use the listing functionality to return specific pages or sorting if needed e.g. give me list of most recently updated users.
@bobjflong @Skaelv 