### PR TITLE
Add example for bulk request

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ result.scroll_param
 result =  = intercom.users.scroll.next("0730e341-63ef-44da-ab9c-9113f886326d");
 
 #Bulk operations.
-# Submit bulk job, to create users, if any of the items in create_items match an existing user that user will be updated
+# Submit bulk job to create users. If any of the items in create_items match an existing user that user will be updated
 intercom.users.submit_bulk_job(create_items: [{user_id: 25, email: "alice@example.com"}, {user_id: 25, email: "bob@example.com"}])
+# Submit bulk job to create users with companies. Companies must be sent as an array of objects nested within each applicable user object 
+intercom.users.submit_bulk_job(create_items: [{user_id: 25, email: "alice@example.com", companies: [{:company_id => 9, :name => "Test Company"}]}])
 # Submit bulk job, to delete users
 intercom.users.submit_bulk_job(delete_items: [{user_id: 25, email: "alice@example.com"}, {user_id: 25, email: "bob@example.com"}])
 # Submit bulk job, to add items to existing job


### PR DESCRIPTION
Right now if you submit a bulk request, but do so incorrectly, you wont find out for awhile due to bulk processing times. By showing an example of how to properly nest companies, I think we can prevent possible mistakes from being made and also prevent CS from being confused.