### PR TITLE
implement find for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ result =  = intercom.users.scroll.next("0730e341-63ef-44da-ab9c-9113f886326d");
 #Bulk operations.
 # Submit bulk job to create users. If any of the items in create_items match an existing user that user will be updated
 intercom.users.submit_bulk_job(create_items: [{user_id: 25, email: "alice@example.com"}, {user_id: 25, email: "bob@example.com"}])
-# Submit bulk job to create users with companies. Companies must be sent as an array of objects nested within each applicable user object 
+# Submit bulk job to create users with companies. Companies must be sent as an array of objects nested within each applicable user object
 intercom.users.submit_bulk_job(create_items: [{user_id: 25, email: "alice@example.com", companies: [{:company_id => 9, :name => "Test Company"}]}])
 # Submit bulk job, to delete users
 intercom.users.submit_bulk_job(delete_items: [{user_id: 25, email: "alice@example.com"}, {user_id: 25, email: "bob@example.com"}])
@@ -313,6 +313,11 @@ intercom.messages.create({
 
 #### Events
 ```ruby
+# Retrieve event list for user with id:'123abc'
+intercom.events.find("type" => "user", "intercom_user_id" => "123abc")
+# Retrieve event summary list for user with user_id:'3204sdf90i32i0ew' or email: 'test@test.com'
+intercom.events.find("type" => "user", "user_id" => "3204sdf90i32i0ew", "summary" => "true")
+intercom.events.find("type" => "user", "email" => "test@test.com", "summary" => "true")
 intercom.events.create(
   :event_name => "invited-friend", :created_at => Time.now.to_i,
   :email => user.email,
@@ -322,8 +327,6 @@ intercom.events.create(
     "found_date" => 12909364407
   }
 )
-
-
 ```
 
 Metadata Objects support a few simple types that Intercom can present on your behalf

--- a/lib/intercom/service/event.rb
+++ b/lib/intercom/service/event.rb
@@ -1,11 +1,13 @@
 require 'intercom/service/base_service'
 require 'intercom/api_operations/save'
 require 'intercom/api_operations/bulk/submit'
+require 'intercom/api_operations/find'
 
 module Intercom
   module Service
     class Event < BaseService
       include ApiOperations::Save
+      include ApiOperations::Find
       include ApiOperations::Bulk::Submit
 
       def collection_class

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -540,6 +540,44 @@ def test_conversation_count
   }
 end
 
+def test_events_list
+  {
+    :events => [
+      {
+        "type"=>"event",
+        "id"=>"69dffca4-7e4a-11e6-a6ba-11ad284998b1",
+        "created_at"=>1474276875,
+        "event_name"=>"invited-friend",
+        "user_id"=>"446",
+        "email"=>"dummy@intercom.io",
+        "intercom_user_id"=>"5591b8d40f8244a7c3000b2c",
+        "metadata"=>{"time_now_at"=>1474276836, "crazy_name"=>"something"}
+      },
+      {
+        "type"=>"event",
+        "id"=>"170351b6-7e4a-11e6-ab63-053fcdba94ec",
+        "created_at"=>1474276736,
+        "event_name"=>"invited-friend",
+        "user_id"=>"446",
+        "email"=>"dummy@intercom.io",
+        "intercom_user_id"=>"5591b8d40f8244a7c3000b2c",
+        "metadata"=>{}
+      }
+    ]
+  }
+end
+
+def test_events_summary_list
+  {
+    # :email => "dummy@intercom.io",
+    :events => [{"name"=>"hamster_catcher", "first"=>"2015-07-02T17:20:22.000Z", "last"=>"2015-07-02T17:20:22.000Z", "count"=>1, "description"=>nil},
+      {"name"=>"invited-friend", "first"=>"2016-09-19T09:18:56.000Z", "last"=>"2016-09-19T09:21:15.000Z", "count"=>2, "description"=>nil}
+    ],
+    # :intercom_user_id=> "5591b8d40f8244a7c3000b2c",
+    # :user_id => "446"
+  }
+end
+
 def error_on_modify_frozen
   RUBY_VERSION =~ /1.8/ ? TypeError : RuntimeError
 end

--- a/spec/unit/intercom/event_spec.rb
+++ b/spec/unit/intercom/event_spec.rb
@@ -23,6 +23,23 @@ describe "Intercom::Event" do
     client.events.create(:event_name => "sale of item", :email => 'joe@example.com')
   end
 
+  describe 'find events' do
+    it "fetches a user's events list" do
+      client.expects(:get).with("/events", {"type" => "user", "intercom_user_id" => "123abc"}).returns(test_events_list)
+      events = client.events.find("type" => "user", "intercom_user_id" => "123abc")
+      events.events.length.must_equal 2
+      events.events[0]["email"].must_equal "dummy@intercom.io"
+      events.events[0]["event_name"].must_equal "invited-friend"
+    end
+    it "fetches a user's events summary list" do
+      client.expects(:get).with("/events", {"type" => "user", "intercom_user_id" => "123abc", "summary" => "true"}).returns(test_events_summary_list)
+      events = client.events.find("type" => "user", "intercom_user_id" => "123abc", "summary" => "true")
+      events.events[1]["name"].must_equal "invited-friend"
+      events.events[1]["count"].must_equal 2
+    end
+
+  end
+
   describe 'bulk operations' do
     let (:job) {
       {


### PR DESCRIPTION
- implement user events list with `find` method since there is no need to modify the api route based on if the hash contains an `:id`
