### PR TITLE
Adding support for multi-page results for Event.find_all.

### DIFF
--- a/lib/intercom/api_operations/find_all.rb
+++ b/lib/intercom/api_operations/find_all.rb
@@ -16,7 +16,7 @@ module Intercom
           finder_details[:url] = "/#{collection_name}"
           finder_details[:params] = params
         end
-        ClientCollectionProxy.new(collection_name, finder_details: finder_details,  client: @client)
+        collection_proxy_class.new(collection_name, finder_details: finder_details,  client: @client)
       end
 
       private

--- a/lib/intercom/service/base_service.rb
+++ b/lib/intercom/service/base_service.rb
@@ -1,3 +1,5 @@
+require 'intercom/client_collection_proxy'
+
 module Intercom
   module Service
     class BaseService
@@ -9,6 +11,10 @@ module Intercom
 
       def collection_class
         raise NotImplementedError
+      end
+
+      def collection_proxy_class
+        Intercom::ClientCollectionProxy
       end
 
       def from_api(api_response)

--- a/lib/intercom/service/event.rb
+++ b/lib/intercom/service/event.rb
@@ -1,8 +1,16 @@
+require 'intercom/client_collection_proxy'
 require 'intercom/service/base_service'
 require 'intercom/api_operations/save'
 require 'intercom/api_operations/bulk/submit'
 
 module Intercom
+  class EventCollectionProxy < ClientCollectionProxy
+
+    def paging_info_present?(response_hash)
+      !!(response_hash['pages'])
+    end
+  end
+
   module Service
     class Event < BaseService
       include ApiOperations::FindAll
@@ -11,6 +19,10 @@ module Intercom
 
       def collection_class
         Intercom::Event
+      end
+
+      def collection_proxy_class
+        Intercom::EventCollectionProxy
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -568,10 +568,22 @@ def test_event_list
     "type" => "event.list",
     "events" => [ test_event ],
     "pages" => {
-      "next" => "https =>//api.intercom.io/events?type=user&intercom_user_id=55a3b&before=144474756550"
+      "next" => "https://api.intercom.io/events?type=user&intercom_user_id=55a3b&before=144474756550"
     }
   }
 end
+
+def page_of_events(include_next_link=false)
+  {
+     "type" => "event.list",
+     "events" => [ test_event ],
+     "pages" =>
+      {
+        "next" => (include_next_link ? "https://api.intercom.io/events?type=user&intercom_user_id=55a3b&before=144474756550" : nil),
+      }
+  }
+end
+
 
 def error_on_modify_frozen
   RUBY_VERSION =~ /1.8/ ? TypeError : RuntimeError


### PR DESCRIPTION
While examining [a PR for python-intercom](https://github.com/jkeyes/python-intercom/pull/141/) I noticed that intercom-ruby doesn't support multi-page results for `Event.find_all.

The API paging support for Events differs to that for the other resources, which means `paging_info_present` will always return `false` as there is no `type` attribute.

 I'm unfamiliar with Ruby, so I hope this PR will prove useful.