### PR TITLE
raise a RateLimitExceeded error when the response code is 429

### DIFF
--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -108,9 +108,9 @@ module Intercom
     end
 
     def execute_request(request)
-      result = request.execute(@base_url, username: @username_part, secret: @password_part)
+      request.execute(@base_url, username: @username_part, secret: @password_part)
+    ensure
       @rate_limit_details = request.rate_limit_details
-      result
     end
 
     def base_url=(new_url)

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -115,6 +115,8 @@ module Intercom
         raise Intercom::AuthenticationError.new('Unauthorized')
       elsif res.code.to_i.eql?(403)
         raise Intercom::AuthenticationError.new('Forbidden')
+      elsif res.code.to_i.eql?(429)
+        raise Intercom::RateLimitExceeded.new('Rate Limit Exceeded')
       elsif res.code.to_i.eql?(500)
         raise Intercom::ServerError.new('Server Error')
       elsif res.code.to_i.eql?(502)

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -8,6 +8,12 @@ describe 'Intercom::Request' do
     proc {req.parse_body('<html>somethjing</html>', response)}.must_raise(Intercom::ServerError)
   end
 
+  it 'raises a RateLimitExceeded error when the response code is 429' do
+    response = OpenStruct.new(:code => 429)
+    req = Intercom::Request.new('path/', 'GET')
+    proc {req.parse_body('<html>somethjing</html>', response)}.must_raise(Intercom::RateLimitExceeded)
+  end
+
   it 'parse_body returns nil if decoded_body is nil' do
     response = OpenStruct.new(:code => 500)
     req = Intercom::Request.new('path/', 'GET')


### PR DESCRIPTION
It looks like the `RateLimitExceeded` exception was not being considered, this PR includes it.