### PR TITLE
Standardize comparison of attribute as string when input is Hash or JSON

### DIFF
--- a/lib/intercom/traits/api_resource.rb
+++ b/lib/intercom/traits/api_resource.rb
@@ -78,13 +78,13 @@ module Intercom
       end
 
       def custom_attribute_field?(attribute)
-        attribute == 'custom_attributes'
+        attribute.to_s == 'custom_attributes'
       end
-      
+
       def message_from_field?(attribute, value)
         attribute.to_s == 'from' && value.is_a?(Hash) && value['type']
       end
-      
+
       def message_to_field?(attribute, value)
         attribute.to_s == 'to' && value.is_a?(Hash) && value['type']
       end
@@ -94,7 +94,7 @@ module Intercom
           !custom_attribute_field?(attribute) &&
           !message_from_field?(attribute, value) &&
           !message_to_field?(attribute, value) &&
-          attribute != 'metadata'
+          attribute.to_s != 'metadata'
       end
 
       def typed_value?(value)
@@ -107,7 +107,7 @@ module Intercom
       end
 
       def type_field?(attribute)
-        attribute == 'type'
+        attribute.to_s == 'type'
       end
 
       def initialize_missing_flat_store_attributes

--- a/spec/unit/intercom/traits/api_resource_spec.rb
+++ b/spec/unit/intercom/traits/api_resource_spec.rb
@@ -17,6 +17,26 @@ describe Intercom::Traits::ApiResource do
        "color"=>"cyan"
      }}
   end
+
+  let(:object_hash) do
+    {
+      type: "company",
+      id: "aaaaaaaaaaaaaaaaaaaaaaaa",
+      app_id: "some-app-id",
+      name: "SuperSuite",
+      plan_id: 1,
+      remote_company_id: "8",
+      remote_created_at: 103201,
+      created_at: 1374056196,
+      user_count: 1,
+      custom_attributes: { type: "ping" },
+      metadata: {
+        type: "user",
+        color: "cyan"
+      }
+    }
+  end
+
   let(:api_resource) { DummyClass.new.extend(Intercom::Traits::ApiResource)}
 
   before(:each) { api_resource.from_response(object_json) }
@@ -76,18 +96,29 @@ describe Intercom::Traits::ApiResource do
     proc { api_resource.send(:flubber=, 'a', 'b') }.must_raise NoMethodError
   end
 
-  it "an initialized ApiResource is equal to on generated from a response" do
+  it "an initialized ApiResource is equal to one generated from a response" do
     class ConcreteApiResource; include Intercom::Traits::ApiResource; end
     initialized_api_resource = ConcreteApiResource.new(object_json)
     except(object_json, 'type').keys.each do |attribute|
       assert_equal initialized_api_resource.send(attribute), api_resource.send(attribute)
     end
   end
-  
+
+  it "initialized ApiResource using hash is equal to one generated from response" do
+    class ConcreteApiResource; include Intercom::Traits::ApiResource; end
+
+    api_resource.from_hash(object_hash)
+    initialized_api_resource = ConcreteApiResource.new(object_hash)
+
+    except(object_json, 'type').keys.each do |attribute|
+      assert_equal initialized_api_resource.send(attribute), api_resource.send(attribute)
+    end
+  end
+
   def except(h, *keys)
     keys.each { |key| h.delete(key) }
     h
   end
-  
+
   class DummyClass; end
 end


### PR DESCRIPTION
Adding `.to_s` properly follows the convention of not initializing `custom_attributes`
or any other attribute which passes the reserve field `type`. Not having `.to_s`, meant
if ApiResource is initialized by `User` or any other class, with a `Hash`, and
the attribute contains the reserved `type` `Hash` attribute, it would incorrectly
try to initialize the same property.

Ex of how it would fail, if `User` class is initialized with custom_attributes that
contains `type`:
```ruby
Intercom::User.new(email: "john@doe.com", custom_attributes: {"type"=>"ping"})
=> Intercom::AttributeNotSetError: 'each' called on Intercom::Ping but it has
not been set an attribute or does not exist as a method

...
```

A workaround would be that all keys were passed as strings, however this PR attempts
at standardizing the comparison of any `attribute` always as string, without
being dependent on input type (`Hash` or `JSON`).

I took additional liberty and applied these changes for `type_field?` and
`typed_property?` check for `metadata` attribute as well. `metadata`, because
 as per the specs, it can contain the reserved `type` `Hash` as well.

Happy to tweak/modify/close, if the changes raise any concern :).