### PR TITLE
add nil check for parsed_body

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -91,7 +91,7 @@ module Intercom
       rescue JSON::ParserError => _
         raise_errors_on_failure(response)
       end
-      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body['type'] == 'error.list'
+      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body&['type'] == 'error.list'
       parsed_body
     end
 

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -19,4 +19,10 @@ describe 'Intercom::Request' do
     req = Intercom::Request.new('path/', 'GET')
     req.parse_body(nil, response).must_equal(nil)
   end
+
+  it 'parse_body returns nil if the decoded_body is "null"' do
+    response = OpenStruct.new(:code => 500)
+    req = Intercom::Request.new('path/', 'GET')
+    req.parse_body('null', response).must_equal(nil)
+  end
 end


### PR DESCRIPTION
Closes #339 

Sometimes, parsing the decoded body will result in a `nil` value (i.e. if the `decoded_body` is `"null"`. Here, we only call `[]` if the `parsed_body` is something that can respond to it. 

Rather than raising a `NoMethodError`, the `parse_body` method will return `nil` if the `decoded_body` parses to `nil`. 