### PR TITLE
Changing version, for some reason it skipped 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.5.18'
+    gem 'intercom', '~> 3.5.19'
 
 ## Basic Usage
 


### PR DESCRIPTION
For some reason it jumped to 3.5.19 as opposed to 3.5.18
Not sure why but updating readme to reflect this