### PR TITLE
Bugfix parse body

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -100,7 +100,7 @@ module Intercom
       rescue JSON::ParserError => _
         raise_errors_on_failure(response)
       end
-      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body&['type'] == 'error.list'
+      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body && parsed_body['type'] == 'error.list'
       parsed_body
     end
 

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -100,7 +100,8 @@ module Intercom
       rescue JSON::ParserError => _
         raise_errors_on_failure(response)
       end
-      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body && parsed_body['type'] == 'error.list'
+      raise_errors_on_failure(response) if parsed_body.nil?
+      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body['type'] == 'error.list'
       parsed_body
     end
 

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -16,6 +16,12 @@ describe 'Intercom::Request' do
     proc {req.parse_body('<html>somethjing</html>', response)}.must_raise(Intercom::RateLimitExceeded)
   end
 
+  it 'parse_body raises an error if the decoded_body is "null"' do
+    response = OpenStruct.new(:code => 500)
+    req = Intercom::Request.new('path/', 'GET')
+    proc { req.parse_body('null', response)}.must_raise(Intercom::ServerError)
+  end
+
   describe 'Intercom::Client' do
     let (:client) { Intercom::Client.new(token: 'foo', handle_rate_limit: true) }
     let (:uri) {"https://api.intercom.io/users"}
@@ -61,11 +67,5 @@ describe 'Intercom::Request' do
     response = OpenStruct.new(:code => 500)
     req = Intercom::Request.new('path/', 'GET')
     assert_nil(req.parse_body(nil, response))
-  end
-
-  it 'parse_body returns nil if the decoded_body is "null"' do
-    response = OpenStruct.new(:code => 500)
-    req = Intercom::Request.new('path/', 'GET')
-    req.parse_body('null', response).must_equal(nil)
   end
 end


### PR DESCRIPTION
Fixes #358 

CC: @choran - it seems that using the lonely operator (`&` ) breaks that method for anyone below Ruby 2.3 - sorry about that. 

Also, it seems that prior to 2.3, `JSON.parse` raises an error when passed a `null` value, rather than just returning `nil`. To be consistent across Ruby versions, seems like it makes more sense to raise an application error if the `decoded_body` is `'null'`, no matter what

Let me know if this seems more sensible!