### PR TITLE
Revert "add nil check for parsed_body"

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -100,7 +100,7 @@ module Intercom
       rescue JSON::ParserError => _
         raise_errors_on_failure(response)
       end
-      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body&['type'] == 'error.list'
+      raise_application_errors_on_failure(parsed_body, response.code.to_i) if parsed_body['type'] == 'error.list'
       parsed_body
     end
 

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -62,10 +62,4 @@ describe 'Intercom::Request' do
     req = Intercom::Request.new('path/', 'GET')
     assert_nil(req.parse_body(nil, response))
   end
-
-  it 'parse_body returns nil if the decoded_body is "null"' do
-    response = OpenStruct.new(:code => 500)
-    req = Intercom::Request.new('path/', 'GET')
-    req.parse_body('null', response).must_equal(nil)
-  end
 end


### PR DESCRIPTION
Reverts intercom/intercom-ruby#353

`&` character in `lib/intercom/request.rb` seems to be causing issues. 

Also reported here: https://github.com/intercom/intercom-ruby/issues/358

Error log from my test below:

```
/Users/dori/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/intercom-3.5.20/lib/intercom/request.rb:103:in `parse_body': undefined method `&' for #<Hash:0x007fd5100e1158> (NoMethodError)
	from /Users/dori/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/intercom-3.5.20/lib/intercom/request.rb:72:in `block in execute'
	from /Users/dori/.rbenv/versions/2.3.1/lib/ruby/2.3.0/net/http.rb:853:in `start'
	from /Users/dori/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/intercom-3.5.20/lib/intercom/request.rb:67:in `execute'
	from /Users/dori/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/intercom-3.5.20/lib/intercom/client.rb:113:in `execute_request'
	from /Users/dori/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/intercom-3.5.20/lib/intercom/client.rb:89:in `get'
	from /Users/dori/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/intercom-3.5.20/lib/intercom/api_operations/find.rb:13:in `find'
	from test-intercom-ruby.rb:16:in `<main>'
```

Manually removing `&` character in `lib/intercom/request.rb` fixes the issue for me. 