### PR TITLE
Added ResourceNotUnique when error-code is 'resource_conflict'

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -42,7 +42,7 @@ module Intercom
   # Raised when requesting resources on behalf of a user that doesn't exist in your application on Intercom.
   class ResourceNotFound < IntercomError; end
 
-  # Raised when requesting resources on behalf of a user that doesn't exist in your application on Intercom.
+  # Raised when trying to create a request that already exists in Intercom.
   class ResourceNotUniqueError < IntercomError; end
 
   # Raised when the request has bad syntax

--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -42,6 +42,9 @@ module Intercom
   # Raised when requesting resources on behalf of a user that doesn't exist in your application on Intercom.
   class ResourceNotFound < IntercomError; end
 
+  # Raised when requesting resources on behalf of a user that doesn't exist in your application on Intercom.
+  class ResourceConflictError < IntercomError; end
+
   # Raised when the request has bad syntax
   class BadRequestError < IntercomError; end
 
@@ -55,13 +58,13 @@ module Intercom
   class MultipleMatchingUsersError < IntercomError; end
 
   # Raised when restoring a blocked user
-  class BlockedUserError < IntercomError ; end
+  class BlockedUserError < IntercomError; end
 
   # Raised when you try to call a non-setter method that does not exist on an object
-  class Intercom::AttributeNotSetError < IntercomError ; end
+  class Intercom::AttributeNotSetError < IntercomError; end
 
   # Raised when unexpected nil returned from server
-  class Intercom::HttpError < IntercomError ; end
+  class Intercom::HttpError < IntercomError; end
 
   #
   # Non-public errors (internal to the gem)

--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -43,7 +43,7 @@ module Intercom
   class ResourceNotFound < IntercomError; end
 
   # Raised when requesting resources on behalf of a user that doesn't exist in your application on Intercom.
-  class ResourceConflictError < IntercomError; end
+  class ResourceNotUniqueError < IntercomError; end
 
   # Raised when the request has bad syntax
   class BadRequestError < IntercomError; end

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -164,7 +164,7 @@ module Intercom
       when 'conflict', 'unique_user_constraint'
         raise Intercom::MultipleMatchingUsersError.new(error_details['message'], error_context)
       when 'resource_conflict'
-        raise Intercom::ResourceConflictError.new(error_details['message'], error_context)
+        raise Intercom::ResourceNotUniqueError.new(error_details['message'], error_context)
       when nil, ''
         raise Intercom::UnexpectedError.new(message_for_unexpected_error_without_type(error_details, parsed_http_code), error_context)
       else

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -163,6 +163,8 @@ module Intercom
         raise Intercom::ServiceUnavailableError.new(error_details['message'], error_context)
       when 'conflict', 'unique_user_constraint'
         raise Intercom::MultipleMatchingUsersError.new(error_details['message'], error_context)
+      when 'resource_conflict'
+        raise Intercom::ResourceConflictError.new(error_details['message'], error_context)
       when nil, ''
         raise Intercom::UnexpectedError.new(message_for_unexpected_error_without_type(error_details, parsed_http_code), error_context)
       else

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -18,7 +18,7 @@ describe 'Intercom::Request' do
 
   it 'raises a ResourceConflictError error when the response code is 429' do
     response = OpenStruct.new(:error_code => 'resource_conflict')
-    req = Intercom::Request.new('path/', 'PUT')
+    req = Intercom::Request.new('path/', 'GET')
     proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::ResourceConflictError)
   end
 

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -16,12 +16,6 @@ describe 'Intercom::Request' do
     proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::RateLimitExceeded)
   end
 
-  it 'raises a ResourceConflictError error when error code is resource_conflict' do
-    response = OpenStruct.new(:error_code => 'resource_conflict')
-    req = Intercom::Request.new('path/', 'GET')
-    proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::ResourceConflictError)
-  end
-
   it 'parse_body raises an error if the decoded_body is "null"' do
     response = OpenStruct.new(:code => 500)
     req = Intercom::Request.new('path/', 'GET')

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -16,7 +16,7 @@ describe 'Intercom::Request' do
     proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::RateLimitExceeded)
   end
 
-  it 'raises a ResourceConflictError error when the response code is 429' do
+  it 'raises a ResourceConflictError error when error code is resource_conflict' do
     response = OpenStruct.new(:error_code => 'resource_conflict')
     req = Intercom::Request.new('path/', 'GET')
     proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::ResourceConflictError)

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -7,13 +7,19 @@ describe 'Intercom::Request' do
   it 'raises an error when a html error page rendered' do
     response = OpenStruct.new(:code => 500)
     req = Intercom::Request.new('path/', 'GET')
-    proc {req.parse_body('<html>somethjing</html>', response)}.must_raise(Intercom::ServerError)
+    proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::ServerError)
   end
 
   it 'raises a RateLimitExceeded error when the response code is 429' do
     response = OpenStruct.new(:code => 429)
     req = Intercom::Request.new('path/', 'GET')
-    proc {req.parse_body('<html>somethjing</html>', response)}.must_raise(Intercom::RateLimitExceeded)
+    proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::RateLimitExceeded)
+  end
+
+  it 'raises a ResourceConflictError error when the response code is 429' do
+    response = OpenStruct.new(:error_code => 'resource_conflict')
+    req = Intercom::Request.new('path/', 'PUT')
+    proc {req.parse_body('<html>something</html>', response)}.must_raise(Intercom::ResourceConflictError)
   end
 
   it 'parse_body raises an error if the decoded_body is "null"' do
@@ -23,8 +29,8 @@ describe 'Intercom::Request' do
   end
 
   describe 'Intercom::Client' do
-    let (:client) { Intercom::Client.new(token: 'foo', handle_rate_limit: true) }
-    let (:uri) {"https://api.intercom.io/users"}
+    let(:client) { Intercom::Client.new(token: 'foo', handle_rate_limit: true) }
+    let(:uri) {"https://api.intercom.io/users"}
 
     it 'should have handle_rate_limit set' do
        client.handle_rate_limit.must_equal(true)


### PR DESCRIPTION
When we get error code resource_conlict from Intercom we want to throw a "ResourceNotUnique" error.