### PR TITLE
Suppress unused variable warnings in the spec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -235,7 +235,7 @@ def users_scroll(include_users= false)
   }
 end
 
-def users_pagination(include_next_link=false, per_page=0, page=0, total_pages=0, total_count=0, user_list=[])
+def users_pagination(include_next_link:, per_page:, page:, total_pages:, total_count:, user_list:)
   {
       "type"=>"user.list",
       "pages"=>

--- a/spec/unit/intercom/client_collection_proxy_spec.rb
+++ b/spec/unit/intercom/client_collection_proxy_spec.rb
@@ -38,21 +38,21 @@ describe Intercom::ClientCollectionProxy do
      test_user("user4@example.com"), test_user("user5@example.com"), test_user("user6@example.com"),
      test_user("user7@example.com"), test_user("user8@example.com"), test_user("user9@example.com"),
      test_user("user10@example.com")]
-    client.expects(:get).with("/users", {:type=>'users', :per_page => 10, :page => 1}).returns(users_pagination(false, per_page=10, page=1, total_pages=1, total_count=10, user_list=users))
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 10, :page => 1}).returns(users_pagination(include_next_link: false, per_page: 10, page: 1, total_pages: 1, total_count: 10, user_list: users))
     result = client.users.find_all(:type=>'users', :per_page => 10, :page => 1).map {|user| user.email }
     result.must_equal %W(user1@example.com user2@example.com user3@example.com user4@example.com user5@example.com user6@example.com user7@example.com user8@example.com user9@example.com user10@example.com)
   end
 
   it "supports multi page pagination" do
     users = [test_user("user3@example.com"), test_user("user4@example.com")]
-    client.expects(:get).with("/users", {:type=>'users', :per_page => 2, :page => 3}).returns(users_pagination(true, per_page=2, page=3, total_pages=5, total_count=10, user_list=users))
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 2, :page => 3}).returns(users_pagination(include_next_link: true, per_page: 2, page: 3, total_pages: 5, total_count: 10, user_list: users))
     result = client.users.find_all(:type=>'users', :per_page => 2, :page => 3).map {|user| user.email }
     result.must_equal %W(user3@example.com user4@example.com)
   end
 
   it "works with page out of range request" do
     users = []
-    client.expects(:get).with("/users", {:type=>'users', :per_page => 2, :page => 30}).returns(users_pagination(true, per_page=2, page=30, total_pages=2, total_count=3, user_list=users))
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 2, :page => 30}).returns(users_pagination(include_next_link: true, per_page: 2, page: 30, total_pages: 2, total_count: 3, user_list: users))
     result = client.users.find_all(:type=>'users', :per_page => 2, :page => 30).map {|user| user.email }
     result.must_equal %W()
   end
@@ -62,7 +62,7 @@ describe Intercom::ClientCollectionProxy do
     time_increment=1000
     users = [test_user_dates(email="user1@example.com", created_at=test_date), test_user_dates(email="user2@example.com", created_at=test_date-time_increment),
              test_user_dates(email="user3@example.com", created_at=test_date-2*time_increment), test_user_dates(email="user4@example.com", created_at=test_date-3*time_increment)]
-    client.expects(:get).with("/users", {:type=>'users', :per_page => 4, :page => 5, :order => "asc", :sort => "created_at"}).returns(users_pagination(true, per_page=4, page=5, total_pages=6, total_count=30, user_list=users))
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 4, :page => 5, :order => "asc", :sort => "created_at"}).returns(users_pagination(include_next_link: true, per_page: 4, page: 5, total_pages: 6, total_count: 30, user_list: users))
     result = client.users.find_all(:type=>'users', :per_page => 4, :page => 5, :order => "asc", :sort => "created_at").map(&:email)
     result.must_equal %W(user1@example.com user2@example.com user3@example.com user4@example.com)
   end
@@ -72,7 +72,7 @@ describe Intercom::ClientCollectionProxy do
     time_increment=1000
     users = [test_user_dates(email="user4@example.com", created_at=3*test_date), test_user_dates(email="user3@example.com", created_at=test_date-2*time_increment),
              test_user_dates(email="user2@example.com", created_at=test_date-time_increment), test_user_dates(email="user1@example.com", created_at=test_date)]
-    client.expects(:get).with("/users", {:type=>'users', :per_page => 4, :page => 5, :order => "desc", :sort => "created_at"}).returns(users_pagination(true, per_page=4, page=5, total_pages=6, total_count=30, user_list=users))
+    client.expects(:get).with("/users", {:type=>'users', :per_page => 4, :page => 5, :order => "desc", :sort => "created_at"}).returns(users_pagination(include_next_link: true, per_page: 4, page: 5, total_pages: 6, total_count: 30, user_list: users))
     result = client.users.find_all(:type=>'users', :per_page => 4, :page => 5, :order => "desc", :sort => "created_at").map {|user| user.email }
     result.must_equal %W(user4@example.com user3@example.com user2@example.com user1@example.com)
   end


### PR DESCRIPTION
Currently, the spec has warnings about unused variables.
The warnings are displayed by warning option of Ruby.

```
$ RUBYOPT='-w' bundle exec rake
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:41: warning: assigned but unused variable - per_page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:41: warning: assigned but unused variable - page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:41: warning: assigned but unused variable - total_pages
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:41: warning: assigned but unused variable - total_count
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:41: warning: assigned but unused variable - user_list
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:48: warning: assigned but unused variable - per_page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:48: warning: assigned but unused variable - page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:48: warning: assigned but unused variable - total_pages
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:48: warning: assigned but unused variable - total_count
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:48: warning: assigned but unused variable - user_list
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:55: warning: assigned but unused variable - per_page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:55: warning: assigned but unused variable - page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:55: warning: assigned but unused variable - total_pages
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:55: warning: assigned but unused variable - total_count
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:55: warning: assigned but unused variable - user_list
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:65: warning: assigned but unused variable - per_page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:65: warning: assigned but unused variable - page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:65: warning: assigned but unused variable - total_pages
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:65: warning: assigned but unused variable - total_count
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:65: warning: assigned but unused variable - user_list
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:75: warning: assigned but unused variable - per_page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:75: warning: assigned but unused variable - page
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:75: warning: assigned but unused variable - total_pages
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:75: warning: assigned but unused variable - total_count
/home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/client_collection_proxy_spec.rb:75: warning: assigned but unused variable - user_list

...
```

This change will suppress theses warnings by using keyword arguments. Keyword argument does not require unneeded assignments, and I think it is more readable.

Note: The spec has other warnings, but this change does not fix other
warnings. Because I'm not sure how to fix these problems.