### PR TITLE
Use `assert_nil` instead of `must_equal nil`

### DIFF
--- a/spec/unit/intercom/user_spec.rb
+++ b/spec/unit/intercom/user_spec.rb
@@ -239,7 +239,7 @@ describe "Intercom::User" do
   it "allows setting dates to nil without converting them to 0" do
     client.expects(:post).with("/users", {"email" => "jo@example.com", 'custom_attributes' => {}, "remote_created_at" => nil}).returns({"email" => "jo@example.com"})
     user = client.users.create("email" => "jo@example.com", "remote_created_at" => nil)
-    user.remote_created_at.must_equal nil
+    assert_nil user.remote_created_at
   end
 
   it "sets/gets rw keys" do


### PR DESCRIPTION
Because it is deprecated.

```
$ bundle exec rake

...

DEPRECATED: Use assert_nil if expecting nil from /home/pocke/ghq/github.com/intercom/intercom-ruby/spec/unit/intercom/user_spec.rb:242. This will fail in Minitest 6.

...
```