### PR TITLE
Remove gem dependency for Ruby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,4 @@ group :development, :test do
     gem 'json-jruby'
     gem 'jruby-openssl'
   end
-  platforms :ruby_18 do
-    gem 'json_pure'
-  end
 end


### PR DESCRIPTION
Because this gem no longer supports Ruby 1.8.

https://github.com/intercom/intercom-ruby/blob/0fda77324201e5090fcbfbccb0a2744d96c73397/intercom.gemspec#L29