### PR TITLE
Update README.md - untag users using email

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ intercom.companies.scroll.each { |comp| puts comp.name}
 # Tag users
 tag = intercom.tags.tag(name: 'blue', users: [{email: "test1@example.com"}])
 # Untag users
-intercom.tags.untag(name: 'blue',  users: [{user_id: "42ea2f1b93891f6a99000427"}])
+intercom.tags.untag(name: 'blue',  users: [{email: "test1@example.com"}])
 # Iterate over all tags
 intercom.tags.all.each {|tag| "#{tag.id} - #{tag.name}" }
 intercom.tags.all.map {|tag| tag.name }


### PR DESCRIPTION
Looks like the README is out of date here, the untag command only accepts lookup via user's email (as far as I can tell!)