### PR TITLE
Updated circle_ci to version 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.2
+    working_directory: ~/intercom-ruby
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,0 @@
-machine:
-  ruby:
-    version: 2.1.0
-test:
-  post:
-  - bundle exec rake


### PR DESCRIPTION
As the title says. Had to bump the machine version to 2.2 as Circle CI sunset the docker machines with 2.1 as well.

cc @theandrewykim