### PR TITLE
handle negative sleep time for rate limit retries

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -74,7 +74,8 @@ module Intercom
             parsed_body
           rescue Intercom::RateLimitExceeded => e
             if @handle_rate_limit
-              sleep (@rate_limit_details[:reset_at] - Time.now.utc).ceil
+              seconds_to_retry = (@rate_limit_details[:reset_at] - Time.now.utc).ceil
+              sleep seconds_to_retry unless seconds_to_retry < 0
               retry unless (retries -=1).zero?
             else
               raise e
@@ -109,7 +110,7 @@ module Intercom
       rate_limit_details = {}
       rate_limit_details[:limit] = response['X-RateLimit-Limit'].to_i if response['X-RateLimit-Limit']
       rate_limit_details[:remaining] = response['X-RateLimit-Remaining'].to_i if response['X-RateLimit-Remaining']
-      rate_limit_details[:reset_at] = Time.at(response['X-RateLimit-Reset'].to_i) if response['X-RateLimit-Reset']
+      rate_limit_details[:reset_at] = Time.parse(response['X-RateLimit-Reset']) if response['X-RateLimit-Reset']
       @rate_limit_details = rate_limit_details
     end
 

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -61,6 +61,17 @@ describe 'Intercom::Request' do
       req.execute(target_base_url=uri, username: "ted", secret: "")
     end
 
+    it 'should not sleep if rate limit reset time has passed' do
+      # Use webmock to mock the HTTP request
+      stub_request(:any, uri).\
+      to_return(status: [429, "Too Many Requests"], headers: { 'X-RateLimit-Reset' => Time.parse("February 25 2010").utc }).\
+      then.to_return(status: [200, "OK"])
+      req = Intercom::Request.get(uri, "")
+      req.handle_rate_limit=true
+      req.expects(:sleep).never.with(any_parameters)
+      req.execute(target_base_url=uri, username: "ted", secret: "")
+    end
+
   end
 
 


### PR DESCRIPTION
For https://github.com/intercom/intercom-ruby/issues/385 

In cases where there is some sort of delay on the ruby server it's possible that the app's rate limit has already been reset. The call should process without breaking. 
