### PR TITLE
Remove json dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 
 group :development, :test do
   platforms :jruby do
-    gem 'json-jruby'
     gem 'jruby-openssl'
   end
 end

--- a/intercom.gemspec
+++ b/intercom.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakeweb", ["~> 1.3"]
   spec.add_development_dependency "pry"
 
-  spec.add_dependency 'json', '>= 1.8'
   spec.required_ruby_version = '>= 2.1.0'
   spec.add_development_dependency 'gem-release'
 end


### PR DESCRIPTION
We should stop pulling in the JSON gem from Rubygems and instead use the version that ships with the language runtime.

Many gems including Rails did this: https://github.com/rails/rails/pull/23453

> All modern Rubies ship JSON as part of stdlib. Using the gem actually hurts multi-platform support due to build difficulties on Windows.