### PR TITLE
Use correct hash key in tagging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ intercom.tags.untag(name: 'blue',  users: [{user_id: "42ea2f1b93891f6a99000427"}
 intercom.tags.all.each {|tag| "#{tag.id} - #{tag.name}" }
 intercom.tags.all.map {|tag| tag.name }
 # Tag companies
-tag = intercom.tags.tag(name: 'blue', companies: [{id: "42ea2f1b93891f6a99000427"}])
+tag = intercom.tags.tag(name: 'blue', companies: [{company_id: "42ea2f1b93891f6a99000427"}])
 ```
 
 #### Segments


### PR DESCRIPTION
#### Why?
The docs contain an incorrect call for tagging companies. The hash key should be `company_id`, not `id`. Passing `id` as a key throws an error.

#### How?
Changed the hash key.