### PR TITLE
Allow all conversations to be listed

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ intercom.notes.find_all(user_id: '123').each {|note| puts note.body}
 
 #### Conversations
 ```ruby
+# Iterate over all conversations for your app
+intercom.conversations.all 
+
 # FINDING CONVERSATIONS FOR AN ADMIN
 # Iterate over all conversations (open and closed) assigned to an admin
 intercom.conversations.find_all(type: 'admin', id: '7').each {|convo| ... }

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ intercom.notes.find_all(user_id: '123').each {|note| puts note.body}
 #### Conversations
 ```ruby
 # Iterate over all conversations for your app
-intercom.conversations.all 
+intercom.conversations.all.each { |convo| ... }
 
 # FINDING CONVERSATIONS FOR AN ADMIN
 # Iterate over all conversations (open and closed) assigned to an admin

--- a/lib/intercom/service/conversation.rb
+++ b/lib/intercom/service/conversation.rb
@@ -9,6 +9,7 @@ module Intercom
   module Service
     class Conversation < BaseService
       include ApiOperations::FindAll
+      include ApiOperations::List
       include ApiOperations::Find
       include ApiOperations::Load
       include ApiOperations::Save

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -291,6 +291,56 @@ def test_conversation
   }
 end
 
+def test_conversation_list
+  {
+    "type" => "conversation.list",
+   "pages" => {
+     "type" => "pages",
+     "page" => 1,
+     "per_page" => 20,
+     "total_pages" => 1
+   },
+   "conversations" => [
+     {
+       "type" => "conversation",
+       "id" => "147",
+       "created_at" => 1400850973,
+       "updated_at" => 1400857494,
+       "conversation_message" => {
+         "type" => "conversation_message",
+         "subject" => "",
+         "body" => "<p>Hi Alice,</p>\n\n<p>We noticed you using our Product, do you have any questions?</p> \n<p>- Jane</p>",
+         "author" => {
+           "type" => "admin",
+           "id" => "25"
+         },
+         "attachments" => [
+           {
+             "name" => "signature",
+             "url" => "http =>//someurl.com/signature.jpg"
+           }
+         ]
+       },
+       "user" => {
+         "type" => "user",
+         "id" => "536e564f316c83104c000020"
+       },
+       "assignee" => {
+         "type" => "admin",
+         "id" => "25"
+       },
+       "open" => true,
+       "read" => true,
+       "conversation_parts" => {
+         "type" => "conversation_part.list",
+         "conversation_parts" => [
+         ]
+       }
+     }
+   ]
+  }
+end
+
 def segment
   {
     "type" => "segment",

--- a/spec/unit/intercom/conversation_spec.rb
+++ b/spec/unit/intercom/conversation_spec.rb
@@ -8,6 +8,11 @@ describe "Intercom::Conversation" do
     client.conversations.find(:id => "147")
   end
 
+  it "gets all conversations" do
+    client.expects(:get).with("/conversations", {}).returns(test_conversation_list)
+    client.conversations.all.each { |c| }
+  end
+
   it 'marks a conversation as read' do
     client.expects(:put).with('/conversations/147', { read: true })
     client.conversations.mark_read('147')


### PR DESCRIPTION
#### Why?
Closes https://github.com/intercom/intercom-ruby/issues/407

#### How?
Adds an `all` method to the `conversations` module.