### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ intercom.conversations.open(id: conversation.id, admin_id: '123')
 intercom.conversations.close(id: conversation.id, admin_id: '123')
 
 # Assign
+# Note: Conversations can be assigned to teams. However, the entity that performs the operation of assigning the conversation has to be a real admin.
 intercom.conversations.assign(id: conversation.id, admin_id: '123', assignee_id: '124')
 
 # Snooze

--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ intercom.conversations.open(id: conversation.id, admin_id: '123')
 intercom.conversations.close(id: conversation.id, admin_id: '123')
 
 # Assign
-# Note: Conversations can be assigned to teams. However, the entity that performs the operation of assigning the conversation has to be a real admin.
+# Note: Conversations can be assigned to teams. However, the entity that performs the operation of assigning the conversation has to be an existing teammate. 
+#       You can use `intercom.admins.all.each {|a| puts a.inspect if a.type == 'admin' }` to list all of your teammates.
 intercom.conversations.assign(id: conversation.id, admin_id: '123', assignee_id: '124')
 
 # Snooze


### PR DESCRIPTION
Update README.md with extra info for assigning conversations to teams
https://github.com/intercom/intercom-ruby/issues/433

#### Why?
The operation of assigning a conversation to a team can be a bit confusing, leading to `404`s in case a `team_id` is used as the `admin_id` in the call.

#### How?
Updating `README.md`
