### PR TITLE
Add tour service to Intercom Ruby SDK

### DIFF
--- a/lib/intercom.rb
+++ b/lib/intercom.rb
@@ -7,6 +7,7 @@ require 'intercom/service/count'
 require 'intercom/service/event'
 require 'intercom/service/message'
 require 'intercom/service/note'
+require 'intercom/service/tour'
 require 'intercom/service/job'
 require 'intercom/service/subscription'
 require 'intercom/service/segment'
@@ -20,6 +21,7 @@ require "intercom/count"
 require "intercom/user"
 require "intercom/company"
 require "intercom/note"
+require "intercom/tour"
 require "intercom/job"
 require "intercom/tag"
 require "intercom/segment"

--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -100,6 +100,10 @@ module Intercom
       Intercom::Service::Job.new(self)
     end
 
+    def tours
+      Intercom::Service::Tour.new(self)
+    end
+
     def get(path, params)
       execute_request Intercom::Request.get(path, params)
     end

--- a/lib/intercom/service/tour.rb
+++ b/lib/intercom/service/tour.rb
@@ -1,0 +1,14 @@
+require 'intercom/service/base_service'
+require 'intercom/api_operations/list'
+
+module Intercom
+  module Service
+    class Tour < BaseService
+      include ApiOperations::List
+
+      def collection_class
+        Intercom::Tour
+      end
+    end
+  end
+end

--- a/lib/intercom/tour.rb
+++ b/lib/intercom/tour.rb
@@ -1,0 +1,8 @@
+
+require 'intercom/traits/api_resource'
+
+module Intercom
+  class Tour
+    include Traits::ApiResource
+  end
+end

--- a/spec/unit/intercom/tour_spec.rb
+++ b/spec/unit/intercom/tour_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "tours" do
+  let (:client) { Intercom::Client.new(app_id: 'app_id',  api_key: 'api_key') }
+  let(:response) {
+    {
+      "type" => "tour.list",
+      "tours" => [
+        {
+          "id" => "1234",
+          "type" => "tour",
+          "title" => "Sample tour",
+        }
+      ]
+    }
+  }
+  it "lists the tours" do
+    client.expects(:get).with("/tours", {}).returns(response)
+    tour = client.tours.all.first
+    expect(tour.id).must_equal "1234"
+    expect(tour.title).must_equal "Sample tour"
+  end
+
+end


### PR DESCRIPTION
#### Why?

We want a messenger app to start tours from via a messenger card. We'll need this API to list the tours during the configure card api. We don't need to update the docs yet since this is just going to be used internally for now.


[Related Tech plan section
](https://docs.google.com/document/d/1nWc44lN97LbAKDZn0hgeYQ9UR3tCtOh-qVWyEXIhqWU/edit#heading=h.grmbezx21knj)