### PR TITLE
Residently conversations last reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ intercom.companies.all.map {|company| company.name }
 # Get a list of users in a company by Intercom Company ID
 intercom.companies.users_by_intercom_company_id(company.id)
 # Get a list of users in a company by external company_id
-intercom.companies.users_by_company_id(company.company_id) 
+intercom.companies.users_by_company_id(company.company_id)
 # Get a large list of companies using scroll
 intercom.companies.scroll.each { |comp| puts comp.name}
 # Please see users scroll for more details of how to use scroll
@@ -198,7 +198,7 @@ intercom.conversations.find_all(email: 'joe@example.com', type: 'user', unread: 
 intercom.conversations.find_all(email: 'joe@example.com', type: 'user', unread: true).each {|convo| ... }
 # Iterate over all conversations for a user with their Intercom user ID
 intercom.conversations.find_all(intercom_user_id: '536e564f316c83104c000020', type: 'user').each {|convo| ... }
-# Iterate over all conversations for a lead 
+# Iterate over all conversations for a lead
 # NOTE: to iterate over a lead's conversations you MUST use their Intercom User ID and type User
 intercom.conversations.find_all(intercom_user_id: lead.id, type: 'user').each {|convo| ... }
 
@@ -221,6 +221,9 @@ intercom.conversations.reply(id: conversation.id, type: 'admin', admin_id: '123'
 # User (identified by email) replies with a comment and attachment
 intercom.conversations.reply(id: conversation.id, type: 'user', email: 'joe@example.com', message_type: 'comment', body: 'foo', attachment_urls: ['http://www.example.com/attachment.jpg'])
 
+#reply to a user's last conversation
+intercom.conversations.reply_to_last(type: 'user', body: 'Thanks again', message_type: 'comment', user_id: '12345', admin_id: '123')
+
 # Open
 intercom.conversations.open(id: conversation.id, admin_id: '123')
 
@@ -228,7 +231,7 @@ intercom.conversations.open(id: conversation.id, admin_id: '123')
 intercom.conversations.close(id: conversation.id, admin_id: '123')
 
 # Assign
-# Note: Conversations can be assigned to teams. However, the entity that performs the operation of assigning the conversation has to be an existing teammate. 
+# Note: Conversations can be assigned to teams. However, the entity that performs the operation of assigning the conversation has to be an existing teammate.
 #       You can use `intercom.admins.all.each {|a| puts a.inspect if a.type == 'admin' }` to list all of your teammates.
 intercom.conversations.assign(id: conversation.id, admin_id: '123', assignee_id: '124')
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ intercom.conversations.open(id: conversation.id, admin_id: '123')
 intercom.conversations.close(id: conversation.id, admin_id: '123')
 
 # Assign
+# Note: Conversations can be assigned to teams. However, the entity that performs the operation of assigning the conversation has to be an existing teammate. 
+#       You can use `intercom.admins.all.each {|a| puts a.inspect if a.type == 'admin' }` to list all of your teammates.
 intercom.conversations.assign(id: conversation.id, admin_id: '123', assignee_id: '124')
 
 # Snooze

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.6.1'
+    gem 'intercom', '~> 3.6.2'
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -372,12 +372,19 @@ The metadata key values in the example are treated as follows-
 ### Contacts
 
 `Contacts` represent logged out users of your application.
+Note that `contacts` are referred to as `leads` in the [Intercom](https://developers.intercom.com/intercom-api-reference/reference#leads)
 
 ```ruby
 # Create a contact
 contact = intercom.contacts.create(email: "some_contact@example.com")
 
-# Update a contact
+# Update a contact (via create method)
+# You can update a contact by calling the create method but you MUST provide an id or user_id
+# If you just provide an email, for example, it will create a new contact
+# See the [API reference](https://developers.intercom.com/intercom-api-reference/reference#update-lead) for more detail
+contact = intercom.contacts.create(email: "rubytest1@example.com", id: "3be0398668071a6bc6850413", name:"update_contact")
+
+# Update a contact (via contact object)
 contact.custom_attributes['foo'] = 'bar'
 intercom.contacts.save(contact)
 

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ contact = intercom.contacts.create(email: "some_contact@example.com")
 # Update a contact (via create method)
 # You can update a contact by calling the create method but you MUST provide an id or user_id
 # If you just provide an email, for example, it will create a new contact
-# See the [API reference](https://developers.intercom.com/intercom-api-reference/reference#update-lead) for more detail
-contact = intercom.contacts.create(email: "rubytest1@example.com", id: "3be0398668071a6bc6850413", name:"update_contact")
+# See https://developers.intercom.com/intercom-api-reference/reference#update-lead for more detail
+contact = intercom.contacts.create(email: "some_contact@example.com", id: "3be0398668071a6bc6850413", name:"update_contact")
 
 # Update a contact (via contact object)
 contact.custom_attributes['foo'] = 'bar'

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,8 @@
+3.6.2
+#384 Add ability to snooze conversation
+You can now snooze conversations in your app via:
+intercom.conversations.snooze(...)
+
 3.6.1
 #430 Allow all conversations to be listed
 You can now iterate over all conversations for your app via:

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.6.1"
+  VERSION = "3.6.2"
 end

--- a/spec/unit/intercom/conversation_spec.rb
+++ b/spec/unit/intercom/conversation_spec.rb
@@ -28,12 +28,7 @@ describe "Intercom::Conversation" do
     client.conversations.reply(id: '147', type: 'user', body: 'Thanks again', message_type: 'comment', user_id: 'ac4', attachment_urls: ["http://www.example.com/attachment.jpg"])
   end
 
-  it 'user replies to last conversation' do
-    client.expects(:post).with('/conversations/last/reply', { type: 'user', body: 'Thanks again', message_type: 'comment', user_id: 'ac4' }).returns(test_conversation)
-    client.conversations.reply_to_last(type: 'user', body: 'Thanks again', message_type: 'comment', user_id: 'ac4')
-  end
-
-  it 'admin replies to last conversation' do
+  it 'sends a reply to a users last conversation from an admin' do
     client.expects(:post).with('/conversations/last/reply', { type: 'admin', body: 'Thanks again', message_type: 'comment', user_id: 'ac4', admin_id: '123' }).returns(test_conversation)
     client.conversations.reply_to_last(type: 'admin', body: 'Thanks again', message_type: 'comment', user_id: 'ac4', admin_id: '123')
   end


### PR DESCRIPTION
#### Why?
Made requested changes to:
https://github.com/intercom/intercom-ruby/pull/406


Also one of the requests they have in there shouldn't work. Admin_id should be supplied to reply to a user's last conversation