### PR TITLE
Bump to 3.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.7.0'
+    gem 'intercom', '~> 3.7.1'
 
 ## Basic Usage
 

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+3.7.1
+Extra version bump after faulty previous bump
+
 3.7.0
 Providing the ability to hard delete users as described here:
 https://developers.intercom.com/intercom-api-reference/reference#archive-a-user

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.7.0"
+  VERSION = "3.7.1"
 end


### PR DESCRIPTION
#### Why?
The last bump to 3.7.0 didn't seem to take effect correctly as evidenced from https://github.com/intercom/intercom-ruby/issues/445.

Bumping again to release properlye
