### PR TITLE
Add CDA Limit Reached Error handling

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -63,6 +63,9 @@ module Intercom
   # Raised when the request throws an error not accounted for
   class UnexpectedError < IntercomError; end
 
+  # Raised when the CDA limit for the app has been reached
+  class CDALimitReachedError < IntercomError; end
+
   # Raised when multiple users match the query (typically duplicate email addresses)
   class MultipleMatchingUsersError < IntercomError; end
 

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -170,6 +170,8 @@ module Intercom
         raise Intercom::ResourceNotFound.new(error_details['message'], error_context)
       when "rate_limit_exceeded"
         raise Intercom::RateLimitExceeded.new(error_details['message'], error_context)
+      when "custom_data_limit_reached"
+        raise Intercom::CDALimitReachedError.new(error_details['message'], error_context)
       when 'service_unavailable'
         raise Intercom::ServiceUnavailableError.new(error_details['message'], error_context)
       when 'conflict', 'unique_user_constraint'


### PR DESCRIPTION
#### Why?
Right now we handle CDA limit exceptions as an unknown error. It isn't an unknown error, we know exactly what's gone wrong - so we should handle it as such.

We now raise this on failure
```ruby
[7] Intercom(GEM)> client.users.save(user)
Intercom::CDALimitReachedError: Custom data limit reached
```
