### PR TITLE
Raise admin not found error

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -51,6 +51,9 @@ module Intercom
   # Raised when requesting resources on behalf of a user that doesn't exist in your application on Intercom.
   class ResourceNotFound < IntercomError; end
 
+  # Raised when requesting an admin that doesn't exist in your Intercom workspace.
+  class AdminNotFound < IntercomError; end
+
   # Raised when trying to create a resource that already exists in Intercom.
   class ResourceNotUniqueError < IntercomError; end
 

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -168,6 +168,8 @@ module Intercom
         raise Intercom::BlockedUserError.new(error_details['message'], error_context)
       when "not_found"
         raise Intercom::ResourceNotFound.new(error_details['message'], error_context)
+      when "admin_not_found"
+        raise Intercom::AdminNotFound.new(error_details['message'], error_context)
       when "rate_limit_exceeded"
         raise Intercom::RateLimitExceeded.new(error_details['message'], error_context)
       when "custom_data_limit_reached"


### PR DESCRIPTION
#### Why?
We currently raise UnexpectedError when an admin isn't found. That isn't the case, we should raise a more informative error here.