### PR TITLE
Add API version support 

### DIFF
--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -1,9 +1,6 @@
 module Intercom
   class MisconfiguredClientError < StandardError; end
   class Client
-    API_VERSIONS = ['1.0', '1.1']
-    private_constant :API_VERSIONS
-
     include Options
     attr_reader :base_url, :rate_limit_details, :username_part, :password_part, :handle_rate_limit, :timeouts, :api_version
 
@@ -28,7 +25,7 @@ module Intercom
       end
     end
 
-    def initialize(app_id: 'my_app_id', api_key: 'my_api_key', token: nil, base_url:'https://api.intercom.io', handle_rate_limit: false, api_version: '1.0')
+    def initialize(app_id: 'my_app_id', api_key: 'my_api_key', token: nil, base_url:'https://api.intercom.io', handle_rate_limit: false, api_version: nil)
       if token
         @username_part = token
         @password_part = ""
@@ -130,8 +127,8 @@ module Intercom
     end
 
     def validate_api_version!
-      error = MisconfiguredClientError.new("api_version must be one of the following: #{API_VERSIONS.join(', ')}")
-      fail error unless API_VERSIONS.include?(@api_version)
+      error = MisconfiguredClientError.new("api_version must be either nil or a valid API version")
+      fail error if (@api_version && Gem::Version.new(@api_version) < Gem::Version.new('1.0'))
     end
 
     def execute_request(request)

--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -81,6 +81,8 @@ module Intercom
   # Raised when unexpected nil returned from server
   class Intercom::HttpError < IntercomError; end
 
+  class ApiVersionInvalid < IntercomError; end
+
   #
   # Non-public errors (internal to the gem)
   #

--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -81,6 +81,7 @@ module Intercom
   # Raised when unexpected nil returned from server
   class Intercom::HttpError < IntercomError; end
 
+  # Raised when an invalid api version is used
   class ApiVersionInvalid < IntercomError; end
 
   #

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -62,12 +62,12 @@ module Intercom
       net
     end
 
-    def execute(target_base_url=nil, username:, secret: nil, read_timeout: 90, open_timeout: 30, api_version:)
+    def execute(target_base_url=nil, username:, secret: nil, read_timeout: 90, open_timeout: 30, api_version: nil)
       retries = 3
       base_uri = URI.parse(target_base_url)
       set_common_headers(net_http_method, base_uri)
       set_basic_auth(net_http_method, username, secret)
-      set_api_version(net_http_method, api_version)
+      set_api_version(net_http_method, api_version) if api_version
       begin
         client(base_uri, read_timeout: read_timeout, open_timeout: open_timeout).start do |http|
           begin
@@ -185,6 +185,8 @@ module Intercom
         raise Intercom::MultipleMatchingUsersError.new(error_details['message'], error_context)
       when 'resource_conflict'
         raise Intercom::ResourceNotUniqueError.new(error_details['message'], error_context)
+      when 'intercom_version_invalid'
+        raise Intercom::ApiVersionInvalid.new(error_details['message'], error_context)
       when nil, ''
         raise Intercom::UnexpectedError.new(message_for_unexpected_error_without_type(error_details, parsed_http_code), error_context)
       else

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -19,6 +19,10 @@ module Intercom
       method.basic_auth(CGI.unescape(username), CGI.unescape(secret))
     end
 
+    def set_api_version(method, api_version)
+      method.add_field('Intercom-Version', api_version)
+    end
+
     def self.get(path, params)
       new(path, Net::HTTP::Get.new(append_query_string_to_url(path, params), default_headers))
     end
@@ -58,11 +62,12 @@ module Intercom
       net
     end
 
-    def execute(target_base_url=nil, username:, secret: nil, read_timeout: 90, open_timeout: 30)
+    def execute(target_base_url=nil, username:, secret: nil, read_timeout: 90, open_timeout: 30, api_version:)
       retries = 3
       base_uri = URI.parse(target_base_url)
       set_common_headers(net_http_method, base_uri)
       set_basic_auth(net_http_method, username, secret)
+      set_api_version(net_http_method, api_version)
       begin
         client(base_uri, read_timeout: read_timeout, open_timeout: open_timeout).start do |http|
           begin

--- a/spec/unit/intercom/client_spec.rb
+++ b/spec/unit/intercom/client_spec.rb
@@ -43,19 +43,15 @@ module Intercom
     end
 
     describe 'API version' do
-      it 'should set the api version default' do
-        client.api_version.must_equal('1.0')
+      it 'does not set the api version by default' do
+        assert_nil(client.api_version)
       end
 
-      it 'should allow api version to be provided' do
-        Client.new(app_id: app_id, api_key: api_key, api_version: '1.1').api_version.must_equal('1.1')
+      it 'allows api version to be provided' do
+        Client.new(app_id: app_id, api_key: api_key, api_version: '1.0').api_version.must_equal('1.0')
       end
 
-      it 'should raise on nil api version' do
-        proc { Client.new(app_id: app_id, api_key: api_key, api_version: nil) }.must_raise MisconfiguredClientError
-      end
-
-      it 'should raise on invalid api version' do
+      it 'raises on invalid api version' do
         proc { Client.new(app_id: app_id, api_key: api_key, api_version: '0.2') }.must_raise MisconfiguredClientError
       end
     end

--- a/spec/unit/intercom/client_spec.rb
+++ b/spec/unit/intercom/client_spec.rb
@@ -51,8 +51,17 @@ module Intercom
         Client.new(app_id: app_id, api_key: api_key, api_version: '1.0').api_version.must_equal('1.0')
       end
 
+      it 'allows api version to be nil' do
+        # matches default behavior, and will honor version set in the Developer Hub
+        assert_nil(Client.new(app_id: app_id, api_key: api_key, api_version: nil).api_version)
+      end
+
       it 'raises on invalid api version' do
         proc { Client.new(app_id: app_id, api_key: api_key, api_version: '0.2') }.must_raise MisconfiguredClientError
+      end
+
+      it 'raises on empty api version' do
+        proc { Client.new(app_id: app_id, api_key: api_key, api_version: '') }.must_raise MisconfiguredClientError
       end
     end
 

--- a/spec/unit/intercom/client_spec.rb
+++ b/spec/unit/intercom/client_spec.rb
@@ -42,6 +42,24 @@ module Intercom
       proc { Client.new(app_id: nil, api_key: nil) }.must_raise MisconfiguredClientError
     end
 
+    describe 'API version' do
+      it 'should set the api version default' do
+        client.api_version.must_equal('1.0')
+      end
+
+      it 'should allow api version to be provided' do
+        Client.new(app_id: app_id, api_key: api_key, api_version: '1.1').api_version.must_equal('1.1')
+      end
+
+      it 'should raise on nil api version' do
+        proc { Client.new(app_id: app_id, api_key: api_key, api_version: nil) }.must_raise MisconfiguredClientError
+      end
+
+      it 'should raise on invalid api version' do
+        proc { Client.new(app_id: app_id, api_key: api_key, api_version: '0.2') }.must_raise MisconfiguredClientError
+      end
+    end
+
     describe 'OAuth clients' do
       it 'supports "token"' do
         client = Client.new(token: 'foo')

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -84,6 +84,14 @@ describe 'Intercom::Request' do
       req = Intercom::Request.put(uri, "")
       expect { req.execute(target_base_url=uri, username: "ted", secret: "") }.must_raise(Intercom::ResourceNotUniqueError)
     end
+
+    it 'should raise ApiVersionInvalid error on intercom_version_invalid code' do
+      # Use webmock to mock the HTTP request
+      stub_request(:put, uri).\
+      to_return(status: [400, "Bad Request"], headers: { 'X-RateLimit-Reset' => (Time.now.utc + 10).to_i.to_s }, body: {type: "error.list", errors: [ code: "intercom_version_invalid" ]}.to_json)
+      req = Intercom::Request.put(uri, "")
+      expect { req.execute(uri, username: "ted", secret: "") }.must_raise(Intercom::ApiVersionInvalid)
+    end
   end
 
   it 'parse_body returns nil if decoded_body is nil' do

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -37,7 +37,7 @@ describe 'Intercom::Request' do
         req = Intercom::Request.get(uri, "")
         req.handle_rate_limit=true
         req.expects(:sleep).times(3).with(any_parameters)
-        req.execute(target_base_url=uri, username: "ted", secret: "")
+        req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
       }.must_raise(Intercom::RateLimitExceeded)
     end
 
@@ -48,7 +48,7 @@ describe 'Intercom::Request' do
       req = Intercom::Request.get(uri, "")
       req.handle_rate_limit=true
       req.expects(:sleep).never.with(any_parameters)
-      req.execute(target_base_url=uri, username: "ted", secret: "")
+      req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
     end
 
     it 'should call sleep for rate limit error just once' do
@@ -59,7 +59,7 @@ describe 'Intercom::Request' do
       req = Intercom::Request.get(uri, "")
       req.handle_rate_limit=true
       req.expects(:sleep).with(any_parameters)
-      req.execute(target_base_url=uri, username: "ted", secret: "")
+      req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
     end
 
     it 'should not sleep if rate limit reset time has passed' do
@@ -70,9 +70,8 @@ describe 'Intercom::Request' do
       req = Intercom::Request.get(uri, "")
       req.handle_rate_limit=true
       req.expects(:sleep).never.with(any_parameters)
-      req.execute(target_base_url=uri, username: "ted", secret: "")
+      req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
     end
-
   end
 
 
@@ -83,7 +82,7 @@ describe 'Intercom::Request' do
       stub_request(:put, uri).\
       to_return(status: [409, "Resource Already Exists"], headers: { 'X-RateLimit-Reset' => (Time.now.utc + 10).to_i.to_s }, body: {type: "error.list", errors: [ code: "resource_conflict" ]}.to_json)
       req = Intercom::Request.put(uri, "")
-      expect { req.execute(target_base_url=uri, username: "ted", secret: "") }.must_raise(Intercom::ResourceNotUniqueError)
+      expect { req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0') }.must_raise(Intercom::ResourceNotUniqueError)
     end
   end
 

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -37,7 +37,7 @@ describe 'Intercom::Request' do
         req = Intercom::Request.get(uri, "")
         req.handle_rate_limit=true
         req.expects(:sleep).times(3).with(any_parameters)
-        req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
+        req.execute(target_base_url=uri, username: "ted", secret: "")
       }.must_raise(Intercom::RateLimitExceeded)
     end
 
@@ -48,7 +48,7 @@ describe 'Intercom::Request' do
       req = Intercom::Request.get(uri, "")
       req.handle_rate_limit=true
       req.expects(:sleep).never.with(any_parameters)
-      req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
+      req.execute(target_base_url=uri, username: "ted", secret: "")
     end
 
     it 'should call sleep for rate limit error just once' do
@@ -59,7 +59,7 @@ describe 'Intercom::Request' do
       req = Intercom::Request.get(uri, "")
       req.handle_rate_limit=true
       req.expects(:sleep).with(any_parameters)
-      req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
+      req.execute(target_base_url=uri, username: "ted", secret: "")
     end
 
     it 'should not sleep if rate limit reset time has passed' do
@@ -70,7 +70,7 @@ describe 'Intercom::Request' do
       req = Intercom::Request.get(uri, "")
       req.handle_rate_limit=true
       req.expects(:sleep).never.with(any_parameters)
-      req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0')
+      req.execute(target_base_url=uri, username: "ted", secret: "")
     end
   end
 
@@ -82,7 +82,7 @@ describe 'Intercom::Request' do
       stub_request(:put, uri).\
       to_return(status: [409, "Resource Already Exists"], headers: { 'X-RateLimit-Reset' => (Time.now.utc + 10).to_i.to_s }, body: {type: "error.list", errors: [ code: "resource_conflict" ]}.to_json)
       req = Intercom::Request.put(uri, "")
-      expect { req.execute(target_base_url=uri, username: "ted", secret: "", api_version: '1.0') }.must_raise(Intercom::ResourceNotUniqueError)
+      expect { req.execute(target_base_url=uri, username: "ted", secret: "") }.must_raise(Intercom::ResourceNotUniqueError)
     end
   end
 


### PR DESCRIPTION
#### Why?
With the release of API v1.1, it's now possible to [specify the version to use via a request header.
](https://developers.intercom.com/building-apps/v1.0/docs/api-versioning#section-selecting-the-version-via-the-api-request)

Currently, it's not possible to do this with the Ruby client. This makes it difficult to migrate to new versions of the API, as the only other way to change versions is via the Developer Hub. Since this setting applies globally (for all endpoints), it doesn't work well when selectively upgrading endpoints. Having finer-grained control over which versions are used for which requests is especially useful when accounting for breaking changes (of which v1.1 has a couple):
![image](https://user-images.githubusercontent.com/1232682/51618891-189cd000-1efd-11e9-958c-acff673e9e7f.png)


#### How?

This PR adds an `api_version` kwarg that can be passed to `Intercom::Client`. This argument defaults to 1.0 (the "base" version, for backward compatibility) and is validated against a set of valid versions (defined in a private constant in the client).

The version set here gets passed through to `request.execute` and ultimately set as a request header ([as outlined in the docs](https://developers.intercom.com/building-apps/v1.0/docs/api-versioning#section-selecting-the-version-via-the-api-request))

Note that [the request header takes precedence over the version set in the Developer Hub](https://developers.intercom.com/building-apps/v1.0/docs/api-versioning#section-can-i-set-the-header-version-and-the-version-in-the-app-).

---

Related issues:
* https://github.com/intercom/intercom-ruby/issues/449
* https://github.com/intercom/intercom-ruby/issues/326
