### PR TITLE
Added error handling for scroll existing already

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -84,6 +84,9 @@ module Intercom
   # Raised when an invalid api version is used
   class ApiVersionInvalid < IntercomError; end
 
+  # Raised when an creating a scroll if one already exists
+  class ScrollAlreadyExistsError < IntercomError; end
+
   #
   # Non-public errors (internal to the gem)
   #

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -187,6 +187,8 @@ module Intercom
         raise Intercom::ResourceNotUniqueError.new(error_details['message'], error_context)
       when 'intercom_version_invalid'
         raise Intercom::ApiVersionInvalid.new(error_details['message'], error_context)
+      when 'scroll_exists'
+        raise Intercom::ScrollAlreadyExistsError.new(error_details['message'], error_context)
       when nil, ''
         raise Intercom::UnexpectedError.new(message_for_unexpected_error_without_type(error_details, parsed_http_code), error_context)
       else


### PR DESCRIPTION
We know when the error we receive is a `scroll_exists` error, we should be surfacing this inside the SDK. 