### PR TITLE
Bump api version to 3.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.7.4'
+    gem 'intercom', '~> 3.7.5'
 
 ## Basic Usage
 
@@ -97,7 +97,7 @@ intercom.users.find_all(type: 'users', page: 1, per_page: 10, created_since: 2, 
 # Paginate through your list of users choosing how many to return per page (default and max is 50 per page)
 intercom.users.find_all(type: 'users', page: 1, per_page: 10, order: :asc).to_a.each_with_index {|usr, i| puts "#{i+1}: #{usr.name}"}
 
-# Duplicate users? If you have duplicate users you can search for them via their email address. 
+# Duplicate users? If you have duplicate users you can search for them via their email address.
 # Note this feature is only available from version 1.1 of the API so you will need to switch to that version
 # This will return multiple users if they have the same email address
 usrs = intercom.users.find_all(type: 'users', email: 'myemail@example.com', page: 1, per_page: 10, order: :asc)

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+3.7.5
+Added error handling for scroll_exists error state
+
 3.7.4
 Added support for API versioning via
 Intercom::Client.new(token: "token", api_version "1.1")

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.7.4"
+  VERSION = "3.7.5"
 end


### PR DESCRIPTION
#### Why?
CC @devinmcgloin bumping rails version to release scroll_exists error handling