### PR TITLE
create an event using a user_id instead of email

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,13 @@ intercom.events.create(
   }
 )
 
+# Alternatively, use "user_id" in case your app allows multiple accounts having the same email
+intercom.events.create(
+  event_name: "invited-friend",
+  created_at: Time.now.to_i,
+  user_id: user.uuid,
+)
+
 # Retrieve event list for user with id:'123abc'
  intercom.events.find_all("type" => "user", "intercom_user_id" => "123abc")
 


### PR DESCRIPTION
#### Why?
Update the readme to state that an event can also be created using a `user_id` as an identifier. Without it, it is not very clear on how to create an event when there is multiple users with the same email.

This is also helpful when there are multiple environments are using the same intercom account for testing purposes.
