### PR TITLE
Gemspec: drop EOL'd property rubyforge_project

### DIFF
--- a/intercom.gemspec
+++ b/intercom.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   spec.summary     = %q{Ruby bindings for the Intercom API}
   spec.description = %Q{Intercom (https://www.intercom.io) is a customer relationship management and messaging tool for web app owners. This library wraps the api provided by Intercom. See http://docs.intercom.io/api for more details. }
   spec.license     = "MIT"
-  spec.rubyforge_project = "intercom"
 
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
#### Why?

The gemspec was using deprecated methods.

The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.

[Source code location with the deprecation](https://github.com/rubygems/rubygems/blob/a7e2f87e94791206d2e7bb12ff7ce75442811ce8/lib/rubygems/specification.rb#L735)


#### How?

Drop the property. No replacement.