### PR TITLE
Raise ResourceNotFound when company is not found (fixes #484)

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -171,7 +171,7 @@ module Intercom
         raise Intercom::BadRequestError.new(error_details['message'], error_context)
       when "not_restorable"
         raise Intercom::BlockedUserError.new(error_details['message'], error_context)
-      when "not_found"
+      when "not_found", "company_not_found"
         raise Intercom::ResourceNotFound.new(error_details['message'], error_context)
       when "admin_not_found"
         raise Intercom::AdminNotFound.new(error_details['message'], error_context)


### PR DESCRIPTION
#### Why?
To raise a more informative exception when a company is not found.

#### How?
I added the `company_not_found` error code to the same case as the `not_found` code.

(Also removed an unused variable from request spec)
