### PR TITLE
Jonny/bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 ## Installation
 
+
     gem install intercom
 
 Using bundler:
 
-    gem 'intercom', '~> 3.8.0'
+    gem 'intercom', '~> 3.8.1'
 
 ## Basic Usage
 

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+3.8.1
+Added error handling for company_not_found
+
 3.8.0
 Add support for Customer Search (currently in Unstable API Version)
 https://developers.intercom.com/intercom-api-reference/v0/reference#customers

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.8.0"
+  VERSION = "3.8.1"
 end


### PR DESCRIPTION
#### Why?
Releases 3.8.1 after https://github.com/intercom/intercom-ruby/pull/485 has been merged.
