### PR TITLE
[chore] test against each major supported Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,35 @@
 version: 2
 jobs:
-  build:
+  "Test against Ruby 2.4":
     docker:
-      - image: circleci/ruby:2.4.6
-
+      - image: circleci/ruby:2.4.9
     working_directory: ~/intercom-ruby
-
     steps:
       - checkout
       - run: bundle install
       - run: bundle exec rake
+  "Test against Ruby 2.5":
+    docker:
+      - image: circleci/ruby:2.5.7
+    working_directory: ~/intercom-ruby
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake
+  "Test against Ruby 2.6":
+    docker:
+      - image: circleci/ruby:2.6.5
+    working_directory: ~/intercom-ruby
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rake
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - "Test against Ruby 2.4"
+      - "Test against Ruby 2.5"
+      - "Test against Ruby 2.6"
+


### PR DESCRIPTION
This adds a nice guarantee that methods used will be reliable for any
version of Ruby gem users may reasonably be using.

- [ ] Update [GitHub checks settings](https://circleci.com/docs/2.0/enable-checks/) to wait for each of the new checks, and not to wait for the old check

Example of the checks settings UI:

![image](https://user-images.githubusercontent.com/4186462/68132164-73774500-fedb-11e9-8434-1e521fe2ed20.png)
