### PR TITLE
Jonny/bump to 3.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.9.0'
+    gem 'intercom', '~> 3.9.2'
 
 ## Basic Usage
 

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,9 @@
+3.9.2
+Added error handling for malformed responses
+
+3.9.1
+Version skipped in error
+
 3.9.0
 Added Teams endpoint functionality
 

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.9.1"
+  VERSION = "3.9.2"
 end


### PR DESCRIPTION
#### Why?
Bumping version up

#### How?
Bumping to 3.9.2 because the version was changed in a previous PR, so the automatic bump tool immediately skipped 3.9.1
Yanking 3.9.2 could cause issues down the line, so simply skipping is fine.
