### PR TITLE
Fix private method error and add test

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -93,8 +93,7 @@ module Intercom
                   :rate_limit_details
 
     private :path,
-            :net_http_method,
-            :rate_limit_details
+            :net_http_method
 
     private def client(uri, read_timeout:, open_timeout:)
       net = Net::HTTP.new(uri.host, uri.port)

--- a/spec/unit/intercom/client_spec.rb
+++ b/spec/unit/intercom/client_spec.rb
@@ -73,6 +73,16 @@ module Intercom
       it 'raises on empty api version' do
         proc { Client.new(app_id: app_id, api_key: api_key, api_version: '') }.must_raise MisconfiguredClientError
       end
+
+      it "assigns works" do
+        stub_request(:any, "https://api.intercom.io/users?id=123").to_return(
+          status: [200, "OK"],
+          headers: { 'X-RateLimit-Reset' => Time.now.utc + 10 },
+          body: { "test": "testing" }.to_json
+        )
+
+        client.get("/users", { id: "123" })
+      end
     end
 
     describe 'OAuth clients' do


### PR DESCRIPTION
#### Why?
Closes https://github.com/intercom/intercom-ruby/issues/498

#### How?
`rate_limit_details` was privatised, but is actually used outside of the request class. This wasn't covered in tests because we never directly made a call to the request class from outside of it.

This adds a test to make sure we're using that class in the client moving forward, and makes the `attr_accessor` not private.
