### PR TITLE
Jonny/bump version once again

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.9.2'
+    gem 'intercom', '~> 3.9.3'
 
 ## Basic Usage
 

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+3.9.3
+Fix regression added in 3.9.2
+
 3.9.2
 Added error handling for malformed responses
 

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.9.2"
+  VERSION = "3.9.3"
 end


### PR DESCRIPTION
#### Why?
Releasing for https://github.com/intercom/intercom-ruby/issues/498 after https://github.com/intercom/intercom-ruby/pull/499
