### PR TITLE
[feature] handle 504 response

### DIFF
--- a/lib/intercom/errors.rb
+++ b/lib/intercom/errors.rb
@@ -42,6 +42,9 @@ module Intercom
   # Raised when we have bad gateway errors.
   class BadGatewayError < IntercomError; end
 
+  # Raised when we have gateway timeout errors.
+  class GatewayTimeoutError < IntercomError; end
+
   # Raised when we experience a socket read timeout
   class ServiceUnavailableError < IntercomError; end
 

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -168,6 +168,8 @@ module Intercom
         raise Intercom::BadGatewayError.new('Bad Gateway Error')
       elsif code == 503
         raise Intercom::ServiceUnavailableError.new('Service Unavailable')
+      elsif code == 504
+        raise Intercom::GatewayTimeoutError.new('Gateway Timeout')
       end
     end
 

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -109,6 +109,15 @@ describe 'Intercom::Request', '#execute' do
 
       expect { execute! }.must_raise(Intercom::RateLimitExceeded)
     end
+
+    it 'raises a GatewayTimeoutError error when the response code is 504' do
+      stub_request(:any, uri).to_return(
+        status: 504,
+        body: '<html> <head><title>504 Gateway Time-out</title></head> <body bgcolor="white"> <center><h1>504 Gateway Time-out</h1></center> </body> </html>'
+      )
+
+      expect { execute! }.must_raise(Intercom::GatewayTimeoutError)
+    end
   end
 
   describe "application error handling" do


### PR DESCRIPTION
Addresses https://github.com/intercom/intercom-ruby/issues/502

Default handling for unexpected response bodies ([here](https://github.com/intercom/intercom-ruby/pull/492))
has revealed an unhandled 504 response from intercom.

Example message from UnexpectedResponseError:

```
Intercom::UnexpectedResponseError, Expected a JSON response body.
Instead got '<html> <head><title>504 Gateway Time-out</title></head>
<body bgcolor="white"> <center><h1>504 Gateway Time-out</h1></center>
</body> </html> ' with status code '504'.
```
