### PR TITLE
 Bump intercom to 3.9.4 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.9.3'
+    gem 'intercom', '~> 3.9.4'
 
 ## Basic Usage
 

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+3.9.4
+Add handling for Gateway Timeouts
+
 3.9.3
 Fix regression added in 3.9.2
 

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.9.3"
+  VERSION = "3.9.4"
 end


### PR DESCRIPTION
#### Why?
Bumping after https://github.com/intercom/intercom-ruby/pull/503
