### PR TITLE
Accept 'Unstable' API Version

### DIFF
--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -136,7 +136,7 @@ module Intercom
 
     def validate_api_version!
       error = MisconfiguredClientError.new("api_version must be either nil or a valid API version")
-      fail error if (@api_version && Gem::Version.new(@api_version) < Gem::Version.new('1.0'))
+      fail error if (@api_version && @api_version != 'Unstable' && Gem::Version.new(@api_version) < Gem::Version.new('1.0'))
     end
 
     def execute_request(request)

--- a/spec/unit/intercom/client_spec.rb
+++ b/spec/unit/intercom/client_spec.rb
@@ -66,6 +66,10 @@ module Intercom
         assert_nil(Client.new(app_id: app_id, api_key: api_key, api_version: nil).api_version)
       end
 
+      it 'allows api version to be Unstable' do
+        Client.new(app_id: app_id, api_key: api_key, api_version: 'Unstable').api_version.must_equal('Unstable')
+      end
+
       it 'raises on invalid api version' do
         proc { Client.new(app_id: app_id, api_key: api_key, api_version: '0.2') }.must_raise MisconfiguredClientError
       end


### PR DESCRIPTION
#### Why?

When trying to use the `Unstable` version, it fails validation, even though it is a valid API version. [See docs](https://developers.intercom.com/building-apps/docs/api-changelog).

```
ArgumentError: Malformed version number string Unstable
```

#### How?

Accept `Unstable` as a valid API version.