### PR TITLE
Bump version to support the unstable API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.9.4'
+    gem 'intercom', '~> 3.9.5'
 
 ## Basic Usage
 

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+3.9.5
+Add Unstable version support
+
 3.9.4
 Add handling for Gateway Timeouts
 

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "3.9.4"
+  VERSION = "3.9.5"
 end


### PR DESCRIPTION
#### Why? 
Releasing 3.9.5