### PR TITLE
Remove patch version from Gemfile twiddle wakka in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This version of the gem is compatible with `Ruby 2.1` and above.
 
 Using bundler:
 
-    gem 'intercom', '~> 3.9.5'
+    gem 'intercom', '~> 3.9'
 
 ## Basic Usage
 


### PR DESCRIPTION
#### Why?

If you specify the patch version in twiddle wakka, `bundle update` will not update it past 3.9.x. Assuming you guys are using semver correctly, just do `~> 3.0` or `~> 3.9`, they mean the same thing and shouldn't break any API calls.

#### How?
Doc update.
