### PR TITLE
[bugfix] Missing client in the response of the object created

### DIFF
--- a/lib/intercom/api_operations/save.rb
+++ b/lib/intercom/api_operations/save.rb
@@ -27,6 +27,7 @@ module Intercom
         else
           response = @client.post("/#{collection_name}", object.to_submittable_hash.merge(identity_hash(object)))
         end
+        object.client = @client
         object.from_response(response) if response # may be nil we received back a 202
       end
 

--- a/spec/unit/intercom/contact_spec.rb
+++ b/spec/unit/intercom/contact_spec.rb
@@ -311,5 +311,60 @@ describe Intercom::Contact do
       client.expects(:delete).with("/contacts/1/companies/#{company.id}", "id": tag.id ).returns(test_company)
       contact.remove_company({ "id": tag.id })
     end
+
+    describe 'just after creating the contact' do
+      let(:contact) do
+        contact = Intercom::Contact.new('email' => 'jo@example.com', :external_id => 'i-1224242')
+        client.expects(:post).with('/contacts', 'email' => 'jo@example.com', 'external_id' => 'i-1224242', 'custom_attributes' => {})
+                             .returns('id' => 1, 'email' => 'jo@example.com', 'external_id' => 'i-1224242')
+        client.contacts.save(contact)
+      end
+
+      it 'returns a collection proxy for listing notes' do
+        proxy = contact.notes
+        _(proxy.resource_name).must_equal 'notes'
+        _(proxy.url).must_equal '/contacts/1/notes'
+        _(proxy.resource_class).must_equal Intercom::Note
+      end
+
+      it 'returns a collection proxy for listing tags' do
+        proxy = contact.tags
+        _(proxy.resource_name).must_equal 'tags'
+        _(proxy.url).must_equal '/contacts/1/tags'
+        _(proxy.resource_class).must_equal Intercom::Tag
+      end
+
+      it 'returns a collection proxy for listing companies' do
+        proxy = contact.companies
+        _(proxy.resource_name).must_equal 'companies'
+        _(proxy.url).must_equal '/contacts/1/companies'
+        _(proxy.resource_class).must_equal Intercom::Company
+      end
+
+      it 'adds a note to a contact' do
+        client.expects(:post).with('/contacts/1/notes', {body: note.body}).returns(note.to_hash)
+        contact.create_note({body: note.body})
+      end
+
+      it 'adds a tag to a contact' do
+        client.expects(:post).with('/contacts/1/tags', "id": tag.id).returns(tag.to_hash)
+        contact.add_tag({ "id": tag.id })
+      end
+
+      it 'removes a tag from a contact' do
+        client.expects(:delete).with("/contacts/1/tags/#{tag.id}", "id": tag.id ).returns(tag.to_hash)
+        contact.remove_tag({ "id": tag.id })
+      end
+
+      it 'adds a contact to a company' do
+        client.expects(:post).with('/contacts/1/companies', "id": company.id).returns(test_company)
+        contact.add_company({ "id": tag.id })
+      end
+
+      it 'removes a contact from a company' do
+        client.expects(:delete).with("/contacts/1/companies/#{company.id}", "id": tag.id ).returns(test_company)
+        contact.remove_company({ "id": tag.id })
+      end
+    end
   end
 end


### PR DESCRIPTION
### Issue

Missing client in the response of the object created.
Then you can not use the nested resources.

#### Example

```ruby
contact = INTERCOM_CLIENT.contacts.new(email: "user@example.com")
INTERCOM_CLIENT.contacts.save(contact)
company = INTERCOM_CLIENT.contacts.new(company_id: "abc-company-example")
contact.add_company(id: company.id) # this fails!!
```

---

Before my fix, the specs that I created were broken:

```
be m spec/unit/intercom/contact_spec.rb 
Mocha deprecation warning at /github/intercom-ruby/spec/spec_helper.rb:5:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
Run options: -n "/^(test_0013_allows\\ setting\\ dates\\ to\\ nil\\ without\\ converting\\ them\\ to\\ 0|test_0015_will\\ allow\\ extra\\ attributes\\ in\\ response\\ from\\ api|test_0001_should\\ be\\ listable|test_0007_allows\\ easy\\ setting\\ of\\ custom\\ data|test_0008_rejects\\ nested\\ data\\ structures\\ in\\ custom_attributes|test_0009_saves\\ a\\ contact\\ \\(always\\ sends\\ custom_attributes\\)|test_0017_can\\ print\\ contacts\\ without\\ crashing|test_0005_is\\ throws\\ a\\ Intercom::AttributeNotSetError\\ on\\ trying\\ to\\ access\\ an\\ attribute\\ that\\ has\\ not\\ been\\ set|test_0003_to_hash'es\\ itself|test_0011_can\\ use\\ client\\.contacts\\.create\\ for\\ convenience|test_0006_presents\\ a\\ complete\\ contact\\ record\\ correctly|test_0020_deletes\\ a\\ contact|test_0002_should\\ throw\\ an\\ ArgumentError\\ when\\ there\\ are\\ no\\ parameters|test_0004_presents\\ created_at\\ and\\ last_impression_at\\ as\\ Date|test_0014_sets/gets\\ rw\\ keys|test_0019_can\\ update\\ a\\ contact\\ with\\ an\\ id|test_0016_returns\\ a\\ BaseCollectionProxy\\ for\\ all\\ without\\ making\\ any\\ requests|test_0012_updates\\ the\\ contact\\ with\\ attributes\\ as\\ set\\ by\\ the\\ server|test_0018_fetches\\ a\\ contact|test_0010_can\\ save\\ a\\ contact\\ with\\ a\\ nil\\ email|test_0001_increments\\ up\\ by\\ 1\\ with\\ no\\ args|test_0003_increments\\ down\\ by\\ given\\ value|test_0005_can\\ call\\ increment\\ on\\ the\\ same\\ key\\ twice\\ and\\ increment\\ by\\ 2|test_0002_increments\\ up\\ by\\ given\\ value|test_0004_can\\ increment\\ new\\ custom\\ data\\ fields|test_0001_decrements\\ down\\ by\\ 1\\ with\\ no\\ args|test_0002_decrements\\ down\\ by\\ given\\ value|test_0003_can\\ decrement\\ new\\ custom\\ data\\ fields|test_0004_can\\ call\\ decrement\\ on\\ the\\ same\\ key\\ twice\\ and\\ decrement\\ by\\ 2|test_0001_should\\ be\\ successful\\ with\\ a\\ lead\\ and\\ user|test_0001_returns\\ a\\ collection\\ proxy\\ for\\ listing\\ notes|test_0004_adds\\ a\\ note\\ to\\ a\\ contact|test_0007_adds\\ a\\ contact\\ to\\ a\\ company|test_0002_returns\\ a\\ collection\\ proxy\\ for\\ listing\\ tags|test_0003_returns\\ a\\ collection\\ proxy\\ for\\ listing\\ companies|test_0005_adds\\ a\\ tag\\ to\\ a\\ contact|test_0006_removes\\ a\\ tag\\ from\\ a\\ contact|test_0008_removes\\ a\\ contact\\ from\\ a\\ company|test_0001_returns\\ a\\ collection\\ proxy\\ for\\ listing\\ notes|test_0007_adds\\ a\\ contact\\ to\\ a\\ company|test_0006_removes\\ a\\ tag\\ from\\ a\\ contact|test_0002_returns\\ a\\ collection\\ proxy\\ for\\ listing\\ tags|test_0003_returns\\ a\\ collection\\ proxy\\ for\\ listing\\ companies|test_0008_removes\\ a\\ contact\\ from\\ a\\ company|test_0004_adds\\ a\\ note\\ to\\ a\\ contact|test_0005_adds\\ a\\ tag\\ to\\ a\\ contact)$/" --seed 7184

# Running:

....E.E.EEE...................................

Finished in 0.014731s, 3122.6858 runs/s, 7399.4076 assertions/s.

  1) Error:
Intercom::Contact::nested resources::just after creating the contact#test_0005_adds a tag to a contact:
NoMethodError: undefined method `post' for nil:NilClass
    /github/intercom-ruby/lib/intercom/api_operations/nested_resource.rb:37:in `block (2 levels) in nested_resource_methods'
    /github/intercom-ruby/spec/unit/intercom/contact_spec.rb:351:in `block (4 levels) in <top (required)>'

  2) Error:
Intercom::Contact::nested resources::just after creating the contact#test_0006_removes a tag from a contact:
NoMethodError: undefined method `delete' for nil:NilClass
    /github/intercom-ruby/lib/intercom/api_operations/nested_resource.rb:44:in `block (2 levels) in nested_resource_methods'
    /github/intercom-ruby/spec/unit/intercom/contact_spec.rb:356:in `block (4 levels) in <top (required)>'

  3) Error:
Intercom::Contact::nested resources::just after creating the contact#test_0004_adds a note to a contact:
NoMethodError: undefined method `post' for nil:NilClass
    /github/intercom-ruby/lib/intercom/api_operations/nested_resource.rb:30:in `block (2 levels) in nested_resource_methods'
    /github/intercom-ruby/spec/unit/intercom/contact_spec.rb:346:in `block (4 levels) in <top (required)>'

  4) Error:
Intercom::Contact::nested resources::just after creating the contact#test_0007_adds a contact to a company:
NoMethodError: undefined method `post' for nil:NilClass
    /github/intercom-ruby/lib/intercom/api_operations/nested_resource.rb:37:in `block (2 levels) in nested_resource_methods'
    /github/intercom-ruby/spec/unit/intercom/contact_spec.rb:361:in `block (4 levels) in <top (required)>'

  5) Error:
Intercom::Contact::nested resources::just after creating the contact#test_0008_removes a contact from a company:
NoMethodError: undefined method `delete' for nil:NilClass
    /github/intercom-ruby/lib/intercom/api_operations/nested_resource.rb:44:in `block (2 levels) in nested_resource_methods'
    /github/intercom-ruby/spec/unit/intercom/contact_spec.rb:366:in `block (4 levels) in <top (required)>'

46 runs, 109 assertions, 0 failures, 5 errors, 0 skips
```
