### PR TITLE
[feature] Conversation : Add/remove nested resource 'contact'

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Resources this API supports:
     https://api.intercom.io/counts
     https://api.intercom.io/subscriptions
     https://api.intercom.io/jobs
-   
+
 
 ### Examples
 
@@ -99,7 +99,7 @@ contacts = intercom.contacts.search(
   }
 )
 contacts.each {|c| p c.email}
-# For full detail on possible queries, please refer to the API documentation: 
+# For full detail on possible queries, please refer to the API documentation:
 # https://developers.intercom.com/intercom-api-reference/reference
 
 # Merge a lead into an existing user
@@ -191,7 +191,7 @@ intercom.data_attributes.save(attribute)
 attribute.archived = true
 intercom.data_attributes.save(attribute)
 
-# Find all customer attributes including archived 
+# Find all customer attributes including archived
 customer_attributes_incl_archived = intercom.data_attributes.find_all({"model": "contact", "include_archived": true})
 customer_attributes_incl_archived.each { |attr| p attribute.name }
 ```
@@ -321,7 +321,7 @@ conversation.statistics.time_to_admin_reply
 conversation.statistics.last_assignment_at
 
 # Get information on the sla applied to a conversation
-conversation.sla_applied.sla_name 
+conversation.sla_applied.sla_name
 
 # REPLYING TO CONVERSATIONS
 # User (identified by email) replies with a comment
@@ -370,9 +370,9 @@ intercom.conversations.mark_read(conversation.id)
 intercom.conversations.run_assignment_rules(conversation.id)
 
 # Search for conversations
-# For full detail on possible queries, please refer to the API documentation: 
-# https://developers.intercom.com/intercom-api-reference/reference 
- 
+# For full detail on possible queries, please refer to the API documentation:
+# https://developers.intercom.com/intercom-api-reference/reference
+
 # Search for open conversations sorted by the created_at date
 conversations = intercom.conversations.search(
   query: {
@@ -386,18 +386,23 @@ conversations = intercom.conversations.search(
 conversations.each {|c| p c.id}
 
 # Tagging for conversations
-tag = intercom.tags.find(id: "2") 
+tag = intercom.tags.find(id: "2")
 conversation = intercom.conversations.find(id: "1")
 
 # An Admin ID is required to add or remove tag on a conversation
-admin = intercom.admins.find(id: "1") 
+admin = intercom.admins.find(id: "1")
 
 # Add a tag to a conversation
 conversation.add_tag(id: tag.id, admin_id: admin.id)
 
 # Remove a tag from a conversation
 conversation.remove_tag(id: tag.id, admin_id: admin.id)
- 
+
+# Add a contact to a conversation
+conversation.add_contact(admin_id: admin.id, customer: { intercom_user_id: contact.id })
+
+# Remove a contact from a conversation
+conversation.remove_tag(id: contact.id, admin_id: admin.id)
 ```
 
 #### Full loading of an embedded entity

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ conversation.remove_tag(id: tag.id, admin_id: admin.id)
 conversation.add_contact(admin_id: admin.id, customer: { intercom_user_id: contact.id })
 
 # Remove a contact from a conversation
-conversation.remove_tag(id: contact.id, admin_id: admin.id)
+conversation.remove_contact(id: contact.id, admin_id: admin.id)
 ```
 
 #### Full loading of an embedded entity

--- a/lib/intercom/conversation.rb
+++ b/lib/intercom/conversation.rb
@@ -7,5 +7,6 @@ module Intercom
     include ApiOperations::NestedResource
 
     nested_resource_methods :tag, operations: %i[add delete]
+    nested_resource_methods :contact, operations: %i[add delete], path: :customers
   end
 end

--- a/spec/unit/intercom/conversation_spec.rb
+++ b/spec/unit/intercom/conversation_spec.rb
@@ -81,5 +81,31 @@ describe "Intercom::Conversation" do
       client.expects(:delete).with("/conversations/1/tags/1", { "id": tag.id }).returns(nil)
       _(proc { conversation.remove_tag({ "id": tag.id }) }).must_raise Intercom::HttpError
     end
+
+    describe 'contacts' do
+      let(:response) do
+        {
+          customers: [
+            { type: test_contact['type'], id: test_contact['id'] }
+          ]
+        }
+      end
+
+      it 'adds a contact to a conversation' do
+        client.expects(:post)
+              .with("/conversations/1/customers",
+                    { admin_id: test_admin['id'], customer: { intercom_user_id: test_contact['id'] } })
+              .returns(response.to_hash)
+        conversation.add_contact(admin_id: test_admin['id'], customer: { intercom_user_id: test_contact['id'] })
+      end
+
+      it 'removes a contact from a conversation' do
+        client.expects(:delete)
+              .with("/conversations/1/customers/aaaaaaaaaaaaaaaaaaaaaaaa",
+                    { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', admin_id: '1234' })
+              .returns(response.to_hash)
+        conversation.remove_contact(id: test_contact['id'], admin_id: test_admin['id'])
+      end
+    end
   end
 end


### PR DESCRIPTION
Implemented `add_contact` and `remove_contact` actions in `Conversation`.

```ruby
# Add a contact to a conversation
conversation.add_contact(admin_id: admin.id, customer: { intercom_user_id: contact.id })

# Remove a contact from a conversation
conversation.remove_tag(id: contact.id, admin_id: admin.id)
```

Fixes https://github.com/intercom/intercom-ruby/issues/515
