### PR TITLE
 Bump intercom to 4.0.1

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,8 @@
-4.0
+4.0.1
+- Fixed bug with nested resources.
+- Support for add/remove contact on conversation object.
+
+4.0.0
 New version to support API version 2.0.
 - Added support for new Contacts API.
 - Added support for Conversation Search and for Conversation model changes.

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end


### PR DESCRIPTION
#### Why?
New release for https://github.com/intercom/intercom-ruby/pull/516 & https://github.com/intercom/intercom-ruby/pull/517

