### PR TITLE
Added support to check for equality of two resources

### DIFF
--- a/lib/intercom/traits/api_resource.rb
+++ b/lib/intercom/traits/api_resource.rb
@@ -17,6 +17,10 @@ module Intercom
         from_hash(attributes)
       end
 
+      def ==(other)
+        self.class == other.class && to_json == other.to_json
+      end
+
       def from_response(response)
         from_hash(response)
         reset_changed_fields!
@@ -34,6 +38,15 @@ module Intercom
       def to_hash
         instance_variables_excluding_dirty_tracking_field.each_with_object({}) do |variable, hash|
           hash[variable.to_s.delete('@')] = instance_variable_get(variable)
+        end
+      end
+
+      def to_json(*args)
+        instance_variables_excluding_dirty_tracking_field.each_with_object({}) do |variable, hash|
+          next if variable == :@client
+
+          value = instance_variable_get(variable)
+          hash[variable.to_s.delete('@')] = value.respond_to?(:to_json) ? value.to_json(*args) : value
         end
       end
 

--- a/spec/unit/intercom/traits/api_resource_spec.rb
+++ b/spec/unit/intercom/traits/api_resource_spec.rb
@@ -112,7 +112,7 @@ describe Intercom::Traits::ApiResource do
   it 'an initialized ApiResource is equal to one generated from a response' do
     class ConcreteApiResource; include Intercom::Traits::ApiResource; end
     initialized_api_resource = ConcreteApiResource.new(object_json)
-    except(object_json, 'type', 'nested_fields').keys.each do |attribute|
+    except(object_json, 'type').keys.each do |attribute|
       assert_equal initialized_api_resource.send(attribute), api_resource.send(attribute)
     end
   end
@@ -122,8 +122,30 @@ describe Intercom::Traits::ApiResource do
 
     api_resource.from_hash(object_hash)
     initialized_api_resource = ConcreteApiResource.new(object_hash)
-    except(object_json, 'type', 'nested_fields').keys.each do |attribute|
+    except(object_json, 'type').keys.each do |attribute|
       assert_equal initialized_api_resource.send(attribute), api_resource.send(attribute)
+    end
+  end
+
+  describe 'correctly equates two resources' do
+    class DummyResource; include Intercom::Traits::ApiResource; end
+
+    specify 'if each resource has the same class and same value' do
+      api_resource1 = DummyResource.new(object_json)
+      api_resource2 = DummyResource.new(object_json)
+      assert_equal (api_resource1 == api_resource2), true
+    end
+
+    specify 'if each resource has the same class and different value' do
+      object2_json = object_json.merge('id' => 'bbbbbb')
+      api_resource1 = DummyResource.new(object_json)
+      api_resource2 = DummyResource.new(object2_json)
+      assert_equal (api_resource1 == api_resource2), false
+    end
+
+    specify 'if each resource has a different class' do
+      dummy_resource = DummyResource.new(object_json)
+      assert_equal (dummy_resource == api_resource), false
     end
   end
 


### PR DESCRIPTION
#### Why?
1. Current setup does not support checking if two resources are equal.
2. Current specs weren't tested with nested_fields which were typed.
https://github.com/intercom/intercom-ruby/blob/ba8e7b724e230d2cfd9ebc28e73a1de59e5f7551/spec/unit/intercom/traits/api_resource_spec.rb#L116
Above spec results in a failure as it tries to equate two resources.

#### How?
- Implemented `.to_json`  at an `ApiResource` level
- Equated based on `.to_json` representation of a resource
 
