### PR TITLE
Add leads method to client

### DIFF
--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -104,6 +104,10 @@ module Intercom
       Intercom::Service::User.new(self)
     end
 
+    def leads
+      Intercom::Service::Lead.new(self)
+    end
+
     def visitors
       Intercom::Service::Visitor.new(self)
     end


### PR DESCRIPTION
#### Why?
This method allows us to use the deprecated `leads` endpoint in the SDK. It was omitted in error during the v4.0 release.

