### PR TITLE
Support for redacting conversation sources and conversation parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ intercom.conversations.reply(id: conversation.id, type: 'admin', admin_id: '123'
 # Reply and Close
 intercom.conversations.reply(id: conversation.id, type: 'admin', admin_id: '123', message_type: 'close', body: 'bar')
 
+# Redact conversation source
+intercom.conversations.redact(id: conversation.id, type: 'source', source_id: '587')
+
+# Redact conversation part
+intercom.conversations.redact(id: conversation.id, type: 'conversation_part', conversation_part_id: '587')
+
 # Admin reply to last conversation
 intercom.conversations.reply_to_last(intercom_user_id: '5678', type: 'admin', admin_id: '123', message_type: 'comment', body: 'bar')
 

--- a/lib/intercom/service/conversation.rb
+++ b/lib/intercom/service/conversation.rb
@@ -61,6 +61,28 @@ module Intercom
         response = @client.post("/#{collection_name}/#{id}/run_assignment_rules")
         collection_class.new.from_response(response)
       end
+
+      def redact(redact_data)
+        redact_type = redact_data.fetch(:type) { raise 'type field is required' }
+        conversation_id = redact_data.delete(:id) { raise 'id field is required' }
+        params = {
+            type: redact_type,
+            conversation_id: conversation_id
+        }
+
+        if redact_type == 'source'
+          source_id = redact_data.fetch(:source_id) { raise 'source_id field is required for type "source"' }
+          params[:source_id] = source_id
+        elsif redact_type == 'conversation_part'
+          conversation_part_id = redact_data.fetch(:conversation_part_id) { raise 'conversation_part_id field is required for type "conversation_part"' }
+          params[:conversation_part_id] = conversation_part_id
+        else
+          raise 'unknown redact_type'
+        end
+
+        response = @client.post("/#{collection_name}/redact", params)
+        collection_class.new.from_response(response)
+      end
     end
   end
 end

--- a/spec/unit/intercom/conversation_spec.rb
+++ b/spec/unit/intercom/conversation_spec.rb
@@ -53,6 +53,16 @@ describe "Intercom::Conversation" do
     client.conversations.snooze(id: '147', admin_id: '123', snoozed_until: tomorrow)
   end
 
+  it 'redacts a source' do
+    client.expects(:post).with('/conversations/redact', { conversation_id: '147', type: 'source', source_id: '587'}).returns(test_conversation)
+    client.conversations.redact(id: '147', type: 'source', source_id: '587')
+  end
+
+  it 'redacts a conversation_part' do
+    client.expects(:post).with('/conversations/redact', { conversation_id: '147', type: 'conversation_part', conversation_part_id: '587'}).returns(test_conversation)
+    client.conversations.redact(id: '147', type: 'conversation_part', conversation_part_id: '587')
+  end
+
   it 'runs assignment rules on a conversation' do
     client.expects(:post).with('/conversations/147/run_assignment_rules').returns(test_conversation)
     client.conversations.run_assignment_rules('147')


### PR DESCRIPTION
#### Why?
I needed support for redacting sources and conversations parts and didn't want to use cURL

#### How?
Tried to follow the pattern for implementing calls and tests

#### Please notice
The redact endpoint returns a HTTP 400 error if you try to redact something that is already redacted. That error is not handled here since 400 errors are not handled. Please advise how to catch that efficiently or consider introducing idempotency for the redact endpoint.
