### PR TITLE
Assign default empty hash to empty post requests

### DIFF
--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -128,7 +128,7 @@ module Intercom
       execute_request Intercom::Request.get(path, params)
     end
 
-    def post(path, payload_hash)
+    def post(path, payload_hash = {})
       execute_request Intercom::Request.post(path, payload_hash)
     end
 


### PR DESCRIPTION
#### Why?
Addresses: https://github.com/intercom/intercom-ruby/issues/540

Could potentially just set this default hash in the `run_assignment_rule` call, but I believe this should be handled at the request level, and we should let the API handle malformed POST requests responses.

