### PR TITLE
refactor error handling

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -158,7 +158,7 @@ module Intercom
     private def raise_errors_on_failure(res)
       code = res.code.to_i
 
-      if code ==429
+      if code == 429
         raise Intercom::RateLimitExceeded, 'Rate Limit Exceeded'
       elsif code == 500
         raise Intercom::ServerError, 'Server Error'

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -158,13 +158,7 @@ module Intercom
     private def raise_errors_on_failure(res)
       code = res.code.to_i
 
-      if code == 404
-        raise Intercom::ResourceNotFound, 'Resource Not Found'
-      elsif code == 401
-        raise Intercom::AuthenticationError, 'Unauthorized'
-      elsif code == 403
-        raise Intercom::AuthenticationError, 'Forbidden'
-      elsif code == 429
+      if code ==429
         raise Intercom::RateLimitExceeded, 'Rate Limit Exceeded'
       elsif code == 500
         raise Intercom::ServerError, 'Server Error'


### PR DESCRIPTION
#### Why?

By allowing the raise_errors_on_failure to handle 4XX code errors, we are skipping our more verbose error handling done in raise_application_errors_on_failure. 

