### PR TITLE
 remove type check

### DIFF
--- a/lib/intercom/client_collection_proxy.rb
+++ b/lib/intercom/client_collection_proxy.rb
@@ -31,7 +31,7 @@ module Intercom
     private
 
     def paging_info_present?(response_hash)
-      !!(response_hash['pages'] && response_hash['pages']['type'])
+      !!(response_hash['pages'])
     end
 
     def extract_next_link(response_hash)


### PR DESCRIPTION
#### Why?
Addresses https://github.com/intercom/intercom-ruby/issues/543

we shouldn't have to check for the existence of the type key. If the pages object exists, the collection should be eligible for pagination.

The Articles endpoint does not contain the type key: 

https://developers.intercom.com/intercom-api-reference/reference#list-all-articles

