### PR TITLE
Add ability to archive/unarchive contacts

### DIFF
--- a/lib/intercom/service/contact.rb
+++ b/lib/intercom/service/contact.rb
@@ -33,6 +33,16 @@ module Intercom
         user.from_response(response)
       end
 
+      def archive(contact)
+        @client.post("/#{collection_name}/#{contact.id}/archive", {})
+        contact
+      end
+
+      def unarchive(contact)
+        @client.post("/#{collection_name}/#{contact.id}/unarchive", {})
+        contact
+      end
+
       private def raise_invalid_merge_error
         raise Intercom::InvalidMergeError, 'Merging can only be performed on a lead into a user'
       end

--- a/spec/unit/intercom/contact_spec.rb
+++ b/spec/unit/intercom/contact_spec.rb
@@ -248,6 +248,18 @@ describe Intercom::Contact do
     client.contacts.delete(contact)
   end
 
+  it 'archives a contact' do
+    contact = Intercom::Contact.new('id' => '1')
+    client.expects(:post).with('/contacts/1/archive', {}).returns(contact)
+    client.contacts.archive(contact)
+  end
+
+  it 'unarchives a contact' do
+    contact = Intercom::Contact.new('id' => '1')
+    client.expects(:post).with('/contacts/1/unarchive', {}).returns(contact)
+    client.contacts.unarchive(contact)
+  end
+
   describe 'merging' do
     let(:lead) { Intercom::Contact.from_api(external_id: 'contact_id', role: 'lead') }
     let(:user) { Intercom::Contact.from_api(id: 'external_id', role: 'user') }


### PR DESCRIPTION
#### Why?

Contacts in Intercom can be archived and unarchived, rather than being deleted outright. The gem doesn't have this ability yet.

#### How?

I've added the methods to the service, following the same style as the api operations. I was considering creating a `SoftArchive` API operation to abstract the operation from the service, but it seems, contacts are the only entities, that have those endpoints.