### PR TITLE
Add empty hash as payload for run assignment rules

### DIFF
--- a/lib/intercom/service/conversation.rb
+++ b/lib/intercom/service/conversation.rb
@@ -58,7 +58,7 @@ module Intercom
 
       def run_assignment_rules(id)
         collection_name = Utils.resource_class_to_collection_name(collection_class)
-        response = @client.post("/#{collection_name}/#{id}/run_assignment_rules")
+        response = @client.post("/#{collection_name}/#{id}/run_assignment_rules", {})
         collection_class.new.from_response(response)
       end
     end

--- a/spec/unit/intercom/conversation_spec.rb
+++ b/spec/unit/intercom/conversation_spec.rb
@@ -54,7 +54,7 @@ describe "Intercom::Conversation" do
   end
 
   it 'runs assignment rules on a conversation' do
-    client.expects(:post).with('/conversations/147/run_assignment_rules').returns(test_conversation)
+    client.expects(:post).with('/conversations/147/run_assignment_rules', {}).returns(test_conversation)
     client.conversations.run_assignment_rules('147')
   end
 


### PR DESCRIPTION
#### Why?
Related to https://github.com/intercom/intercom-ruby/pull/546
