### PR TITLE
Add support for listing contact segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ contact.create_note(body: "<p>Text for the note</p>")
 # List notes for a contact
 contact.notes.each {|n| p n.body}
 
+# List segments for a contact
+contact.segments.each {|segment| p segment.name}
+
 # Add a contact to a company
 company = intercom.companies.find(id: "123")
 contact.add_company(id: company.id)

--- a/lib/intercom/contact.rb
+++ b/lib/intercom/contact.rb
@@ -13,6 +13,7 @@ module Intercom
     nested_resource_methods :tag, operations: %i[add delete list]
     nested_resource_methods :note, operations: %i[create list]
     nested_resource_methods :company, operations: %i[add delete list]
+    nested_resource_methods :segment, operations: %i[list]
 
     def self.collection_proxy_class
       Intercom::BaseCollectionProxy

--- a/lib/intercom/segment.rb
+++ b/lib/intercom/segment.rb
@@ -3,5 +3,9 @@ require 'intercom/traits/api_resource'
 module Intercom
   class Segment
     include Traits::ApiResource
+
+    def self.collection_proxy_class
+      Intercom::BaseCollectionProxy
+    end
   end
 end

--- a/spec/unit/intercom/contact_spec.rb
+++ b/spec/unit/intercom/contact_spec.rb
@@ -273,6 +273,13 @@ describe Intercom::Contact do
       _(proxy.resource_class).must_equal Intercom::Note
     end
 
+    it 'returns a collection proxy for listing segments' do
+      proxy = contact.segments
+      _(proxy.resource_name).must_equal 'segments'
+      _(proxy.url).must_equal '/contacts/1/segments'
+      _(proxy.resource_class).must_equal Intercom::Segment
+    end
+
     it 'returns a collection proxy for listing tags' do
       proxy = contact.tags
       _(proxy.resource_name).must_equal 'tags'


### PR DESCRIPTION
#### Why?
Support for listing contact segments was added in `API v2.2` ([Docs](https://developers.intercom.com/intercom-api-reference/reference#list-attached-segments))

#### How?
Adding segments as a nested resource for `Contact`
