### PR TITLE
Revert "refactor error handling"

### DIFF
--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -158,7 +158,13 @@ module Intercom
     private def raise_errors_on_failure(res)
       code = res.code.to_i
 
-      if code == 429
+      if code == 404
+        raise Intercom::ResourceNotFound, 'Resource Not Found'
+      elsif code == 401
+        raise Intercom::AuthenticationError, 'Unauthorized'
+      elsif code == 403
+        raise Intercom::AuthenticationError, 'Forbidden'
+      elsif code == 429
         raise Intercom::RateLimitExceeded, 'Rate Limit Exceeded'
       elsif code == 500
         raise Intercom::ServerError, 'Server Error'


### PR DESCRIPTION
Reverts intercom/intercom-ruby#548

Reverting as there might be a few error codes not handled, and this could result in a breaking change.
For example, The following error codes are used for with a http status code `404`,
`team_not_found`, `assignee_not_found`, `tag_not_found` & `conversation_part_or_message_not_found`

If we would've gone ahead with this change,
The existing `Intercom::ResourceNotFound` errors would switch to an `Intercom::UnexpectedError`.

This could break existing integrations that are possibly dependent on it.
There might be more error codes that would end up with the same behaviour for `404`, `401` & `403`.

