### PR TITLE
Instance level dynamic accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,13 +700,13 @@ intercom = Intercom::Client.new(token: ENV['AT'], handle_rate_limit: true)
 
 ```bash
 # all tests
-bundle exec spec
+bundle exec rake spec
 
 # unit tests
-bundle exec spec:unit
+bundle exec rake spec:unit
 
 # integration tests
-bundle exec spec:integration
+bundle exec rake spec:integration
 
 # single test file
 bundle exec m spec/unit/intercom/job_spec.rb

--- a/lib/intercom/lib/dynamic_accessors.rb
+++ b/lib/intercom/lib/dynamic_accessors.rb
@@ -5,20 +5,19 @@ module Intercom
       class << self
 
         def define_accessors(attribute, value, object)
-          klass = object.class
           if attribute.to_s.end_with?('_at') && attribute.to_s != 'update_last_request_at'
-            define_date_based_accessors(attribute, value, klass)
+            define_date_based_accessors(attribute, value, object)
           elsif object.flat_store_attribute?(attribute)
-            define_flat_store_based_accessors(attribute, value, klass)
+            define_flat_store_based_accessors(attribute, value, object)
           else
-            define_standard_accessors(attribute, value, klass)
+            define_standard_accessors(attribute, value, object)
           end
         end
 
         private
 
-        def define_flat_store_based_accessors(attribute, value, klass)
-          klass.class_eval %Q"
+        def define_flat_store_based_accessors(attribute, value, object)
+          object.instance_eval %Q"
             def #{attribute}=(value)
               mark_field_as_changed!(:#{attribute})
               @#{attribute} = Intercom::Lib::FlatStore.new(value)
@@ -29,8 +28,8 @@ module Intercom
           "
         end
 
-        def define_date_based_accessors(attribute, value, klass)
-          klass.class_eval %Q"
+        def define_date_based_accessors(attribute, value, object)
+          object.instance_eval %Q"
             def #{attribute}=(value)
               mark_field_as_changed!(:#{attribute})
               @#{attribute} = value.nil? ? nil : value.to_i
@@ -41,8 +40,8 @@ module Intercom
           "
         end
 
-        def define_standard_accessors(attribute, value, klass)
-            klass.class_eval %Q"
+        def define_standard_accessors(attribute, value, object)
+            object.instance_eval %Q"
               def #{attribute}=(value)
                 mark_field_as_changed!(:#{attribute})
                 @#{attribute} = value

--- a/spec/unit/intercom/contact_spec.rb
+++ b/spec/unit/intercom/contact_spec.rb
@@ -274,6 +274,7 @@ describe Intercom::Contact do
 
   describe 'nested resources' do
     let(:contact) { Intercom::Contact.new(id: '1', client: client) }
+    let(:contact_no_tags) { Intercom::Contact.new(id: '2', client: client, tags: []) }
     let(:company) { Intercom::Company.new(id: '1') }
     let(:tag) { Intercom::Tag.new(id: '1') }
     let(:note) { Intercom::Note.new(body: "<p>Text for the note</p>") }
@@ -297,6 +298,27 @@ describe Intercom::Contact do
       _(proxy.resource_name).must_equal 'tags'
       _(proxy.url).must_equal '/contacts/1/tags'
       _(proxy.resource_class).must_equal Intercom::Tag
+    end
+
+    it 'returns correct tags from differring contacts' do
+      client.expects(:get).with('/contacts/1/tags', {}).returns({
+        'type' => 'tag.list',
+        'tags' => [
+          {
+            'type' => 'tag',
+            'id' => '1',
+            'name' => 'VIP Customer'
+          },
+          {
+            'type' => 'tag',
+            'id' => '2',
+            'name' => 'Test tag'
+          }
+        ]
+      })
+
+      _(contact_no_tags.tags.map{ |t| t.id }).must_equal []
+      _(contact.tags.map{ |t| t.id }).must_equal ['1', '2']
     end
 
     it 'returns a collection proxy for listing companies' do


### PR DESCRIPTION
#### Why?

We have observed strange behaviour when fetching a contact's tags in our usage of `intercom-ruby`. Specifically, the `contact.tags` method returning `nil` for contacts who definitely have tags in our Intercom workspace.
Upon further investigation, we discovered when this was occurring, the API call was never being made.
We were able to replicate the issue in our test environment by having multiple tests that access a contact's tags run in succession.

This fix moves the dynamic accessors (assumedly used for caching?) from the class-level to the instance-level to avoid polluting data across multiple contacts.

#### How?

Amended `/lib/intercom/lib/dynamic_accessors.rb` to use `object.instance_eval` instead of `klass.class_eval`.

This avoids the `contacts.tags` method defined by `nested_resource_methods` in `/lib/intercom/api_operations/nested_resource.rb` being overwritten by the dynamic method to return `@tags` **on a class level**. Instead, the individual instance method will be overwritten.

This prevents other instances of contact returning `nil` when calling `contact.tags` (because their instance variable `@tags` has never been set).
