### PR TITLE
Add Intercom::GatewayTimeoutError to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ Intercom::RateLimitExceeded
 Intercom::AttributeNotSetError # Raised when you try to call a getter that does not exist on an object
 Intercom::MultipleMatchingUsersError
 Intercom::HttpError # Raised when response object is unexpectedly nil
+Intercom::GatewayTimeoutError
 ```
 
 ### Rate Limiting


### PR DESCRIPTION
#### Why?
This error was missing from the list of errors in README
