### PR TITLE
fix bug rate_limit_details returned and a bug for intercom request header

### DIFF
--- a/lib/intercom/client.rb
+++ b/lib/intercom/client.rb
@@ -156,7 +156,7 @@ module Intercom
       request.handle_rate_limit = handle_rate_limit
       request.execute(@base_url, token: @token, api_version: @api_version, **timeouts)
     ensure
-      @rate_limit_details = request.rate_limit_details
+      @rate_limit_details = request.rate_limit_details unless request.rate_limit_details.empty?
     end
 
     attr_writer :base_url

--- a/lib/intercom/request.rb
+++ b/lib/intercom/request.rb
@@ -72,11 +72,11 @@ module Intercom
             parsed_body
           rescue Intercom::RateLimitExceeded => e
             if @handle_rate_limit
-              seconds_to_retry = (@rate_limit_details[:reset_at] - Time.now.utc).ceil
+              seconds_to_retry = ((@rate_limit_details[:reset_at] || Time.now.utc) - Time.now.utc).ceil
               if (retries -= 1) < 0
                 raise Intercom::RateLimitExceeded, 'Rate limit retries exceeded. Please examine current API Usage.'
               else
-                sleep seconds_to_retry unless seconds_to_retry < 0
+                sleep seconds_to_retry unless seconds_to_retry <= 0
                 retry
               end
             else

--- a/spec/unit/intercom/client_spec.rb
+++ b/spec/unit/intercom/client_spec.rb
@@ -87,6 +87,14 @@ module Intercom
 
         client.get('/contacts', id: '123')
       end
+
+      it 'sets rate limit details to empty hash' do
+        stub_request(:any, "https://api.intercom.io/test").to_raise(StandardError)
+
+        expect { client.get('/test', {}) }.must_raise(StandardError)
+
+        client.rate_limit_details.must_equal({})
+      end
     end
 
     describe 'OAuth clients' do

--- a/spec/unit/intercom/request_spec.rb
+++ b/spec/unit/intercom/request_spec.rb
@@ -51,6 +51,17 @@ describe 'Intercom::Request', '#execute' do
     execute!
   end
 
+  it 'should not call sleep for rate limit if reset is not received' do
+    stub_request(:any, uri).to_return(
+      status: [429, "Too Many Requests"],
+    ).then.to_return(status: [200, "OK"], body: default_body)
+
+    req.handle_rate_limit=true
+    req.expects(:sleep).never.with(any_parameters)
+
+    execute!
+  end
+
   it 'should not sleep if rate limit reset time has passed' do
     stub_request(:any, uri).to_return(
       status: [429, "Too Many Requests"],


### PR DESCRIPTION
Fix bug rate_limit_details returned as nil if net:http failed a request, and bug if intercom request header does not contain X-RateLimit-Reset header

#### Why?
Why are you making this change?

We have experienced a "bug" when using this library, we implemented our own sidekiq throttle limiter with existing `rate_limit_details`. It worked fine until at one point(my guess is) NET:HTTP request started failing and `rate_limit_details` was being returned as nil.

Another potential issue is if intercom does not return `X-RateLimit-Reset` header, the app will break because it will try to calculate try to subtract some time from Nil.

#### How?
Technical details on your change

For rate_limit_details:
1. Not setting `request.rate_limit_details` if its nil, because it should be empty hash in the initialiser.
2. Another solution is to pass `rate_limit_details` to request object. It's kind of an anti-pattern that both classes are initialising the same variable and both of them are using it. We should initialise it in Client, pass it to Request, Request can modify it and send it back if needed.

For bug prone date arithmetic:
1. Set current time if reset_at is not returned(if its NIL that is) so that the library does not throw used - on NIL object error.
2. We should not call sleep if the sleep amount is 0.
