### PR TITLE
Fix collection successive iterations when there are multiple pages

### DIFF
--- a/lib/intercom/base_collection_proxy.rb
+++ b/lib/intercom/base_collection_proxy.rb
@@ -58,6 +58,7 @@ module Intercom
         @params[:starting_after] = paging_next['starting_after']
         return true
       else
+        @params[:starting_after] = nil
         return false
       end
     end

--- a/spec/unit/intercom/base_collection_proxy_spec.rb
+++ b/spec/unit/intercom/base_collection_proxy_spec.rb
@@ -4,7 +4,7 @@ describe Intercom::BaseCollectionProxy do
   let(:client) { Intercom::Client.new(token: 'token') }
 
   it "stops iterating if no starting after value" do
-    client.expects(:get).with("/contacts", {}). returns(page_of_contacts(false))
+    client.expects(:get).with("/contacts", {}).returns(page_of_contacts(false))
     emails = []
     client.contacts.all.each { |contact| emails << contact.email }
     _(emails).must_equal %w[test1@example.com test2@example.com test3@example.com]
@@ -15,6 +15,7 @@ describe Intercom::BaseCollectionProxy do
     client.expects(:get).with('/contacts', { starting_after: "EnCrYpTeDsTrInG" }).returns(page_of_contacts(false))
     emails = []
     client.contacts.all.each { |contact| emails << contact.email }
+    _(emails).must_equal %w[test1@example.com test2@example.com test3@example.com test1@example.com test2@example.com test3@example.com]
   end
 
   it "supports indexed array access" do
@@ -26,5 +27,21 @@ describe Intercom::BaseCollectionProxy do
     client.expects(:get).with("/contacts", {}).returns(page_of_contacts(false))
     emails = client.contacts.all.map { |contact| contact.email }
     _(emails).must_equal %w[test1@example.com test2@example.com test3@example.com]
+  end
+
+  it "keeps entire collection iterable after first iteration" do
+    contacts = client.contacts.all
+    emails_iter1 = []
+    emails_iter2 = []
+    expects_pagination = proc do
+      client.expects(:get).with("/contacts", {}).returns(page_of_contacts(true))
+      client.expects(:get).with("/contacts", { starting_after: "EnCrYpTeDsTrInG" }).returns(page_of_contacts(false))
+    end
+
+    expects_pagination.call
+    contacts.each { |contact| emails_iter1 << contact.email }
+    expects_pagination.call
+    contacts.each { |contact| emails_iter2 << contact.email }
+    _(emails_iter1).must_equal emails_iter2
   end
 end


### PR DESCRIPTION
#### Why?
While using this gem, my team noticed that when you assign a collection with pagination to a variable (like the result of calling the search endpoint or simply listing all records of a resource), the collection can be entirely iterated only once.
After the first iteration, you can only access the last page of the cursor.

Here's a simple use case in which you'll experience this problem:
```
leads          = @intercom.contacts.search(...) # Collection with enough results to have pagination
total_leads    = leads.count                    # First iteration to count the results
iterated_leads = 0

leads.each { |lead| iterated_leads += 1 }       # Only the last page of the pagination cursor is being iterated, resulting in iterated_leads != total_leads
```
Later, we realized this is happening because the instance variable that controls the iteration through pages is not reset after the last page is fetched.
#### How?
The proposal is to reset the variable `@params[:starting_after]` before leaving the iteration loop. 

**Tests**
- I added a unit test to validate the fix.
- Also, changes were introduced in two existing tests, one to fix a typo and other to add what I think it was a forgotten assert.