### PR TITLE
Updating readme according to new version changes -2.6 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,16 @@ intercom.messages.create({
   },
   body: "halp"
 })
+
+#From version 2.6 the type contact is not supported and you would have to use leads to send messages to a lead.
+
+intercom.messages.create({
+  from: {
+    type: "lead",
+    id: "536e5643as316c83104c400671"
+  },
+  body: "halp"
+})
 ```
 
 #### Admins


### PR DESCRIPTION
## Why?
The [Create Conversation endpoint](https://developers.intercom.com/intercom-api-reference/reference/create-a-conversation) now expects lead and user in request payload. Previously this endpoint accepted values of contact and user.

## How?
Updating the readme file accordingly