### PR TITLE
Adding SDK endpoint to delete an archived contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ intercom.contacts.unarchive(contact)
 # Delete a contact permanently
 intercom.contacts.delete(contact)
 
+# Deletes an archived contact permanently
+contact.delete_archived_contact("124")
+
 # List all contacts
 contacts = intercom.contacts.all
 contacts.each { |contact| p contact.name }

--- a/lib/intercom/service/contact.rb
+++ b/lib/intercom/service/contact.rb
@@ -43,6 +43,10 @@ module Intercom
         contact
       end
 
+      def delete_archived_contact(id)
+        @client.delete("/#{collection_name}/#{id}", {})
+      end
+
       private def raise_invalid_merge_error
         raise Intercom::InvalidMergeError, 'Merging can only be performed on a lead into a user'
       end

--- a/spec/unit/intercom/contact_spec.rb
+++ b/spec/unit/intercom/contact_spec.rb
@@ -260,6 +260,12 @@ describe Intercom::Contact do
     client.contacts.unarchive(contact)
   end
 
+  it 'deletes an archived contact' do
+    contact = Intercom::Contact.new('id' => '1','archived' =>true)
+    client.expects(:delete).with('/contacts/1', {})
+    client.contacts.delete_archived_contact("1")
+  end
+
   describe 'merging' do
     let(:lead) { Intercom::Contact.from_api(external_id: 'contact_id', role: 'lead') }
     let(:user) { Intercom::Contact.from_api(id: 'external_id', role: 'user') }


### PR DESCRIPTION
## Why?
The change is introduced to update the SDK to support the latest change of the delete contact API.

The change:

The [Delete Contact endpoint](https://developers.intercom.com/intercom-api-reference/v2.6/reference/delete-contact) now allows permanent deletion of archived contacts directly. Previously, when attempting to delete an archived contact via the API, the contact needed to be unarchived and then deleted. This is no longer necessary.

Closes https://github.com/intercom/intercom/issues/259039 

## How?
Added a new endpoint to delete an archived contact.

