### PR TITLE
Fix query params not being used in Intercom::BaseCollectionProxy

### DIFF
--- a/lib/intercom/base_collection_proxy.rb
+++ b/lib/intercom/base_collection_proxy.rb
@@ -68,10 +68,7 @@ module Intercom
     end
 
     def payload
-      payload = {}
-      payload[:per_page] = @params[:per_page] if @params[:per_page]
-      payload[:starting_after] = @params[:starting_after] if @params[:starting_after]
-      payload
+      @params.keep_if { |k, v| !v.nil? }.to_h
     end
   end
 end

--- a/spec/unit/intercom/base_collection_proxy_spec.rb
+++ b/spec/unit/intercom/base_collection_proxy_spec.rb
@@ -44,4 +44,9 @@ describe Intercom::BaseCollectionProxy do
     contacts.each { |contact| emails_iter2 << contact.email }
     _(emails_iter1).must_equal emails_iter2
   end
+
+  it "supports query params" do
+    client.expects(:get).with("/conversations", {:intercom_user_id => 'abcdef0000'}).returns(test_conversation_list)
+    _(client.conversations.find_all(:intercom_user_id => 'abcdef0000').map(&:id)).must_equal %w[147]
+  end
 end


### PR DESCRIPTION
Arbitrary `@query` params could be passed in to filter resources, e.g. via the `#find_all` method. These params were not being forwarded through to the underlying HTTP client by BaseCollectionProxy in the same way that they are in ClientCollectionProxy.

Fixes #602.
