### PR TITLE
Handle hyphens in `locale` when fetching Articles with `translated_content`

### DIFF
--- a/lib/intercom/traits/api_resource.rb
+++ b/lib/intercom/traits/api_resource.rb
@@ -73,9 +73,9 @@ module Intercom
 
       def initialize_property(attribute, value)
         return if addressable_list?(attribute, value)
-
-        Lib::DynamicAccessors.define_accessors(attribute, value, self) unless accessors_already_defined?(attribute)
-        set_property(attribute, value)
+        safe_attribute = attribute.to_s.include?("-") ? attribute.to_s.gsub("-", "_") : attribute
+        Lib::DynamicAccessors.define_accessors(safe_attribute, value, self) unless accessors_already_defined?(safe_attribute)
+        set_property(safe_attribute, value)
       end
 
       def addressable_list?(attribute, value)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,14 +10,473 @@ include WebMock::API
 
 def test_article
   {
-      "id": "1",
-      "type": "article",
-      "workspace_id": "tx2p130c",
-      "title": "new title",
-      "description": "test Finished articles are visible when they're added to a Help Center collection",
-      "body": "<p>thingbop</p>",
-      "author_id": 1,
-      "state": "draft"
+      "id" => "1",
+      "type" => "article",
+      "workspace_id" => "tx2p130c",
+      "title" => "new title",
+      "description" => "test Finished articles are visible when they're added to a Help Center collection",
+      "body" => "<p>thingbop</p>",
+      "author_id" => 1,
+      "state" => "draft"
+  }
+end
+
+def test_article_with_translations
+  {
+    "type" => "article",
+    "id" => "6871119",
+    "workspace_id" => "hfi1bx4l",
+    "title" => "Default language title",
+    "description" => "Default language description",
+    "body" => "Default language body in html",
+    "author_id" => "5017691",
+    "state" => "published",
+    "created_at" => 1672928359,
+    "updated_at" => 1672928610,
+    "url" => "http://intercom.test/help/en/articles/3-default-language",
+    "parent_id" => "125685",
+    "parent_ids" => [
+      18,
+      19
+    ],
+    "parent_type" => "collection",
+    "default_locale" => "en",
+    "translated_content" => {
+      "type" => "article_translated_content",
+      "ar" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "bg" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "bs" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "ca" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "cs" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "da" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "de" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "el" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "en" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "es" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "et" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "fi" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "fr" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "he" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "hr" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "hu" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "id" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "it" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "ja" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "ko" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "lt" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "lv" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "mn" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "nb" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "nl" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "pl" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "pt" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "ro" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "ru" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "sl" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "sr" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "sv" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "tr" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "vi" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "pt-BR" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "zh-CN" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      },
+      "zh-TW" => {
+        "type" => "article_content",
+        "title" => "How to create a new article",
+        "description" => "This article will show you how to create a new article.",
+        "body" => "This is the body of the article.",
+        "author_id" => "5017691",
+        "state" => "draft",
+        "created_at" => 1663597223,
+        "updated_at" => 1663597260,
+        "url" => "http://intercom.test/help/en/articles/3-default-language"
+      }
+    },
+    "statistics" => {
+      "type" => "article_statistics",
+      "views" => 10,
+      "conversions" => 0,
+      "reactions" => 10,
+      "happy_reaction_precentage" => 40,
+      "netural_reaction_precentage" => 40,
+      "sad_reaction_precentage" => 20
+    }
+  }
+end
+
+def test_article_list
+  {
+    "type" => "list",
+    "pages" => {
+      "type" => "pages",
+      "page" => 1,
+      "per_page" => 25,
+      "total_pages" => 1
+      },
+    "total_count" => 2,
+    "data" => [
+      test_article,
+      test_article_with_translations
+    ]
   }
 end
 

--- a/spec/unit/intercom/article_spec.rb
+++ b/spec/unit/intercom/article_spec.rb
@@ -8,6 +8,18 @@ describe "Intercom::Article" do
       client.expects(:get).with("/articles/1", {}).returns(test_article)
       client.articles.find(id: "1")
     end
+
+    it "successfully finds an article with translations" do
+      client.expects(:get).with("/articles/1", {}).returns(test_article_with_translations)
+      client.articles.find(id: "1")
+    end
+  end
+
+  describe "Listing Articles" do
+    it "successfully finds all articles" do
+      client.expects(:get).with("/articles", {}).returns(test_article_list)
+      client.articles.all.to_a
+    end
   end
 
   describe "Creating an Article" do


### PR DESCRIPTION
Certain locales include hyphens, which causes trouble (i.e. a `SyntaxError`) when dynamically defining method names.

This change converts the hyphen to an underscore for safety.

#### Why?
Without this, calling e.g. `intercom_client.articles.all.to_a` will raise a `SyntaxError` if the articles have translated content, as it tries to define a method with a hyphen for certain locales (e.g. `pt-BR`).

#### How?
The update checks for `-` in attributes and, if present, replaces with `_` before defining accessors and using the setter.

I experimented with pushing this lower (into the `DynamicAccessors`) but the `ApiResource#initialize_property` immediately calls `set_property` using the same `attribute` name, so we'd then end up having to do this sanitization in multiple places which felt weird.

#### Other thoughts
When writing the specs I was tempted to add a new directory, e.g. `spec/fixtures/articles/`, and store the sample article JSON there vs. pasting it directly in `spec_helper`. For simplicity/consistency I mimicked the current approach but wanted to share my instinct in case useful input 😅.

I also considered trimming the test article hash down to just a couple _representative_ locales to keep it shorter (i.e. a local without a hyphen and a locale _with_ a hyphen), but I thought it better to keep the representation as a mirror of what is actually returned.