### PR TITLE
Fix deprecated mocha version

### DIFF
--- a/intercom.gemspec
+++ b/intercom.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.4'
   spec.add_development_dependency "m", "~> 1.5.0"
   spec.add_development_dependency 'rake', '~> 10.3'
-  spec.add_development_dependency 'mocha', '~> 1.0'
+  spec.add_development_dependency 'mocha', '~> 2.0'
   spec.add_development_dependency "fakeweb", ["~> 1.3"]
   spec.add_development_dependency "pry"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'intercom'
 require 'minitest/autorun'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'webmock'
 require 'time'
 require 'pry'


### PR DESCRIPTION
Context:
-Doing this because of PR https://github.com/intercom/intercom-ruby/pull/619
-Main issue https://github.com/intercom/intercom/issues/418231
This PR updates our testing dependencies to be compatible with Ruby 2.6:

  1. Updated Mocha integration method (spec/spec_helper.rb)
    - Changed from deprecated mocha/setup to explicit mocha/minitest
    - This eliminates the deprecation warning and ensures proper framework detection
  2. Upgraded Mocha version (intercom.gemspec)
    - Updated from ~> 1.0 to ~> 2.0
    - Mocha 2.x includes proper support for the MiniTest → Minitest transition
