### PR TITLE
Bump version to 4.2.1

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,7 @@
+4.2.1
+- Fixed FlatStore to skip hash values when building API request payloads
+- Removed hash validation on FlatStore reads to allow for custom objects
+
 4.1.3
 - Updated ReadMe with more errors.
 - Fixed issue where paginated requests could only be iterated through once.

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "4.2.0"
+  VERSION = "4.2.1"
 end


### PR DESCRIPTION
## Summary
- Bumps gem version from 4.2.0 to 4.2.1
- Updates changelog to document recent FlatStore improvements
- PRs included:
-  https://github.com/intercom/intercom-ruby/pull/619
-  https://github.com/intercom/intercom-ruby/pull/620
- https://github.com/intercom/intercom-ruby/pull/603
- https://github.com/intercom/intercom-ruby/pull/604
- https://github.com/intercom/intercom-ruby/pull/605
## Changelog Entry
- Fixed FlatStore to skip hash values when building API request payloads
- Removed hash validation on FlatStore reads to allow for custom objects

## Context
This version includes the recent fix that prevents custom objects (hashes) in FlatStore from being sent in API requests, which was causing API errors. The fix allows these objects to be stored locally for read operations while filtering them out during save operations.

🤖 Generated with [Claude Code](https://claude.ai/code)