### PR TITLE
Bump version to 4.2.2

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,4 @@
-4.2.1
+4.2.2
 - Fixed FlatStore to skip hash values when building API request payloads
 - Removed hash validation on FlatStore reads to allow for custom objects
 

--- a/lib/intercom/version.rb
+++ b/lib/intercom/version.rb
@@ -1,3 +1,3 @@
 module Intercom #:nodoc:
-  VERSION = "4.2.1"
+  VERSION = "4.2.2"
 end


### PR DESCRIPTION
## Context
- There was an issue where the version 4.2.1 was already released but not tracked in the repo, causing this PR to not have any effect: https://github.com/intercom/intercom-ruby/pull/621 bumping the version again
## Summary
- Bumps gem version from 4.2.1 to 4.2.2
- Updates changelog entry for FlatStore improvements

## Changes
- Updated `lib/intercom/version.rb`: 4.2.1 → 4.2.2
- Updated `changes.txt`: Version number in changelog

## Context
This version includes the FlatStore improvements that prevent custom objects (hashes) from being sent in API requests while allowing them to be stored locally. These changes were already merged but need a new version number.

## Release Notes
- Fixed FlatStore to skip hash values when building API request payloads
- Removed hash validation on FlatStore reads to allow for custom objects

🤖 Generated with [Claude Code](https://claude.ai/code)